### PR TITLE
Fixes for Windows/MinGW compilation

### DIFF
--- a/src/ModelingSystem/ModelingSystemGAMS.cpp
+++ b/src/ModelingSystem/ModelingSystemGAMS.cpp
@@ -25,6 +25,10 @@
 #include "GamsLicensing.h"
 #endif
 
+#if defined(_WIN32)
+# define WEXITSTATUS(x) (x)
+#endif
+
 #include <cstdio> // for tmpnam()
 #include <cstdlib> // for mkdtemp()
 #include <fstream>
@@ -299,7 +303,7 @@ void ModelingSystemGAMS::createModelFromProblemFile(const std::string& filename)
     createdtmpdir = true;
 
     /* create empty convertd options file */
-    std::ofstream convertdopt(fs::filesystem::path(tmpdirname) / "convertd.opt", std::ios::out);
+    std::ofstream convertdopt((fs::filesystem::path(tmpdirname) / "convertd.opt").string(), std::ios::out);
     if(!convertdopt.good())
     {
         throw std::logic_error("Could not create convertd options file.");
@@ -314,16 +318,16 @@ void ModelingSystemGAMS::createModelFromProblemFile(const std::string& filename)
      */
     std::string gamscall;
 #ifdef GAMSDIR
-    gamscall = fs::filesystem::path(GAMSDIR) / "gams";
+    gamscall = (fs::filesystem::path(GAMSDIR) / "gams").string();
 #else
     gamscall = "gams";
 #endif
     gamscall += " \"" + filename + "\"";
     gamscall += " SOLVER=CONVERTD PF4=0 SOLPRINT=0 LIMCOL=0 LIMROW=0 PC=2";
     gamscall += " SCRDIR=" + tmpdirname;
-    gamscall += " OUTPUT=" + std::string(fs::filesystem::path(tmpdirname) / "listing");
+    gamscall += " OUTPUT=" + (fs::filesystem::path(tmpdirname) / "listing").string();
     gamscall += " OPTFILE=1 OPTDIR=" + tmpdirname;
-    gamscall += " LO=3 > " + std::string(fs::filesystem::path(tmpdirname) / "gamsconvert.log");
+    gamscall += " LO=3 > " + (fs::filesystem::path(tmpdirname) / "gamsconvert.log").string();
     // printf(gamscall.c_str()); fflush(stdout);
 
     rc = system(gamscall.c_str());
@@ -342,7 +346,7 @@ void ModelingSystemGAMS::createModelFromProblemFile(const std::string& filename)
         else
             msg = "GAMS call returned with execution error:\n";
 
-        std::ifstream lst(fs::filesystem::path(tmpdirname) / "listing");
+        std::ifstream lst((fs::filesystem::path(tmpdirname) / "listing").string());
         std::string line;
         while(lst.good() && !lst.eof())
         {
@@ -400,7 +404,7 @@ void ModelingSystemGAMS::createModelFromProblemFile(const std::string& filename)
             break;
         }
 
-        std::ifstream log(fs::filesystem::path(tmpdirname) / "gamsconvert.log");
+        std::ifstream log((fs::filesystem::path(tmpdirname) / "gamsconvert.log").string());
         std::string line;
         msg += " GAMS log:\n";
         while(log.good() && !log.eof())
@@ -415,7 +419,7 @@ void ModelingSystemGAMS::createModelFromProblemFile(const std::string& filename)
     }
     }
 
-    createModelFromGAMSModel(fs::filesystem::path(tmpdirname) / "gamscntr.dat");
+    createModelFromGAMSModel((fs::filesystem::path(tmpdirname) / "gamscntr.dat").string());
 
     /* since we ran convert with options file, GMO now stores convertd.opt as options file, which we don't want to use
      * as a SHOT options file */
@@ -590,7 +594,7 @@ void ModelingSystemGAMS::clearGAMSObjects()
     /* remove temporary directory content (should have only files) and directory itself) */
     if(createdtmpdir)
     {
-        std::filesystem::remove_all(tmpdirname);
+        fs::filesystem::remove_all(tmpdirname);
         createdtmpdir = false;
     }
 }

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -200,12 +200,12 @@ bool Solver::setProblem(std::string fileName)
     fs::filesystem::path problemExtension = problemFile.extension();
     fs::filesystem::path problemPath = problemFile.parent_path();
 
-    env->settings->updateSetting("ProblemFile", "Input", problemFile.string());
+    env->settings->updateSetting("ProblemFile", "Input", fs::filesystem::absolute(problemFile).string());
 
     // Removes path
     fs::filesystem::path problemName = problemFile.stem();
     env->settings->updateSetting("ProblemName", "Input", problemName.string());
-    env->settings->updateSetting("ProblemFile", "Input", problemFile.string());
+    env->settings->updateSetting("ProblemFile", "Input", fs::filesystem::absolute(problemFile).string());
 
     // Sets the debug path if not already set
     if(env->settings->getSetting<std::string>("Debug.Path", "Output") == "")
@@ -214,14 +214,14 @@ bool Solver::setProblem(std::string fileName)
             == ES_OutputDirectory::Program)
         {
             fs::filesystem::path debugPath(fs::filesystem::current_path());
-            debugPath /= problemName;
+            debugPath /= ("debug" / problemName);
 
-            env->settings->updateSetting("Debug.Path", "Output", "debug/" + problemName.string());
+                      env->settings->updateSetting("Debug.Path", "Output", debugPath.string());
         }
         else
         {
             fs::filesystem::path debugPath(problemPath);
-            debugPath /= problemName;
+            debugPath /= ("debug" / problemName);
 
             env->settings->updateSetting("Debug.Path", "Output", debugPath.string());
         }
@@ -385,7 +385,7 @@ bool Solver::setProblem(SHOT::ProblemPtr problem, SHOT::ModelingSystemPtr modeli
         fs::filesystem::path debugPath(fs::filesystem::current_path());
         debugPath /= problem->name;
 
-        env->settings->updateSetting("Debug.Path", "Output", "problemdebug/" + problem->name);
+        env->settings->updateSetting("Debug.Path", "Output", debugPath.string());
         env->settings->updateSetting("ResultPath", "Output", fs::filesystem::current_path().string());
     }
 
@@ -1294,8 +1294,9 @@ void Solver::initializeDebugMode()
         }
     }
 
-    fs::filesystem::path source(env->settings->getSetting<std::string>("ProblemFile", "Input"));
-    fs::filesystem::copy_file(fs::filesystem::canonical(source), debugDir / source.filename(),
+    fs::filesystem::path source(fs::filesystem::canonical( env->settings->getSetting<std::string>("ProblemFile", "Input")));
+
+    fs::filesystem::copy_file(source.string(), (debugDir / source.filename()).string(),
         fs::filesystem::copy_options::overwrite_existing);
 }
 


### PR DESCRIPTION
There were some issues when using mingw and compiling for Windows. Probably due to the usage of std::experimental::filesystem. The following fixes seem to work for Windows. 

Also, it seems that Windows does not have the WEXITSTATUS macro, so I added it. I am not sure if it would return the correct values though... 

I have not tried linking SHOT to GAMS on Windows, but at least it compiles with these fixes.