### PR TITLE
allow to access more information about settings

### DIFF
--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -264,6 +264,21 @@ std::string Settings::getEnumDescriptionListMarkup(std::string name, std::string
     return desc.str();
 }
 
+std::vector<std::pair<int, std::string> > Settings::getEnumDescription(std::string name, std::string category)
+{
+   std::vector<std::pair<int, std::string> > r;
+
+   for(auto& E : enumDescriptions)
+   {
+       if(name == std::get<1>(E.first) && category == std::get<0>(E.first))
+       {
+          r.push_back(std::pair<int, std::string>(std::get<2>(E.first), E.second));
+       }
+   }
+
+   return r;
+}
+
 // General methods ================================================================
 
 std::string Settings::getSettingsAsOSoL()
@@ -694,6 +709,26 @@ VectorString Settings::getSettingIdentifiers(E_SettingType type)
     }
 
     return (names);
+}
+
+VectorPairString Settings::getSettingSplitIdentifiers(E_SettingType type)
+{
+   VectorPairString names;
+
+   for(auto& T : settingTypes)
+   {
+       auto key = T.first;
+       std::string name = T.first.second;
+       std::string category = T.first.first;
+
+       if(settingIsPrivate[key])
+           continue; // Do not include an internal setting
+
+       if(T.second == type)
+           names.push_back(T.first);
+   }
+
+   return (names);
 }
 
 bool Settings::readSettingsFromOSoL(std::string osol)

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -146,6 +146,16 @@ public:
         return (value->second);
     }
 
+    std::string getSettingDescription(std::string name, std::string category)
+    {
+       return settingDescriptions.at(PairString(category, name));
+    }
+
+    PairDouble getSettingBounds(std::string name, std::string category)
+    {
+       return settingBounds.at(PairString(category, name));
+    }
+
     void createSetting(
         std::string name, std::string category, std::string value, std::string description, bool isPrivate = false);
 
@@ -166,9 +176,14 @@ public:
         settingGroupDescriptions.emplace(make_pair(mainLevel, subLevel), make_pair(header, description));
     }
 
+    PairString getCategoryDescription(std::string category)
+    {
+       return settingGroupDescriptions.at(PairString(category, ""));
+    }
+
     std::string getEnumDescriptionList(std::string name, std::string category);
     std::string getEnumDescriptionListMarkup(std::string name, std::string category);
-    std::string getEnumDescription(std::string name, std::string category);
+    std::vector<std::pair<int, std::string> > getEnumDescription(std::string name, std::string category);
 
     std::string getSettingsAsOSoL();
     std::string getSettingsAsString(bool showUnchanged, bool showDescriptions);
@@ -176,6 +191,7 @@ public:
 
     VectorString getChangedSettings();
     VectorString getSettingIdentifiers(E_SettingType type);
+    VectorPairString getSettingSplitIdentifiers(E_SettingType type);
 
     bool readSettingsFromOSoL(std::string osol);
     bool readSettingsFromString(std::string options);

--- a/src/Structs.h
+++ b/src/Structs.h
@@ -103,6 +103,7 @@ using PairString = std::pair<std::string, std::string>;
 using VectorDouble = std::vector<double>;
 using VectorInteger = std::vector<int>;
 using VectorString = std::vector<std::string>;
+using VectorPairString = std::vector<PairString>;
 
 struct PairIndexValue
 {


### PR DESCRIPTION
This adds some getter-functions to Settings to make the list of settings, with their description, bounds, etc available.
I would like to have something like that (so feel free to change names, etc) for some code that writes out the SHOT options specifications into a GAMS-internal form. So something similar to your Settings::getSettingsXyz().