### PR TITLE
Mingw output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ if(NOT CMAKE_BUILD_TYPE MATCHES Debug)
 endif()
 
 option(COMPILE_TESTS "Should the automated tests be compiled" OFF)
+option(SIMPLE_OUTPUT_CHARS "Whether to avoid using special characters in the console output (for example on MinGW)" OFF)
 
 # Activates extra functionality, note that corresponding libraries may be needed
 
@@ -593,6 +594,11 @@ if(MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++17")
     add_definitions(-D_USE_MATH_DEFINES)
 endif(MSVC)
+
+# Extra flags for MinGW
+if (MINGW)
+    add_definitions(-DSIMPLE_OUTPUT_CHARS)
+endif(MINGW)
 
 # Set compiler warnings levels
 if(MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -596,9 +596,9 @@ if(MSVC)
 endif(MSVC)
 
 # Extra flags for MinGW
-if (MINGW)
+if (MSVC OR MSYS OR MINGW)
     add_definitions(-DSIMPLE_OUTPUT_CHARS)
-endif(MINGW)
+endif()
 
 # Set compiler warnings levels
 if(MSVC)

--- a/src/Report.cpp
+++ b/src/Report.cpp
@@ -250,6 +250,26 @@ void Report::outputIterationDetailHeader()
     header << "\r\n";
     header << "                                                                                     \n";
 
+#ifdef SIMPLE_OUTPUT_CHARS
+    header << "    Iteration     |  Time  |  Dual cuts  |     Objective value     |   Objective gap   |     Current "
+              "solution\r\n";
+
+    if(env->problem->objectiveFunction->properties.isMinimize)
+    {
+        header
+            << "     #: type      |  tot.  |   + | tot.  |       dual | primal     |    abs. | rel.    |    obj.fn. | "
+               "max.err.\r\n";
+    }
+    else
+    {
+        header
+            << "     #: type      |  tot.  |   + | tot.  |     primal | dual       |    abs. | rel.    |    obj.fn. | "
+               "max.err.\r\n";
+    }
+
+    header << "----------------------------------------------------------------------------------------------------"
+              "----------------";
+#else
     header << "    Iteration     │  Time  │  Dual cuts  │     Objective value     │   Objective gap   │     Current "
               "solution\r\n";
 
@@ -265,9 +285,11 @@ void Report::outputIterationDetailHeader()
             << "     #: type      │  tot.  │   + | tot.  │     primal | dual       │    abs. | rel.    │    obj.fn. | "
                "max.err.\r\n";
     }
+
     header << "╶─────────────────┴────────┴─────────────┴─────────────────────────┴───────────────────┴────────────"
-              "────"
-              "───────────╴\r\n";
+              "───────────────╴";
+#endif
+
     header << "\r\n";
 
     env->output->outputInfo(header.str());
@@ -279,9 +301,15 @@ void Report::outputIterationDetailHeaderMinimax()
     std::stringstream header;
     header << "                                                                                     \n";
 
+#ifdef SIMPLE_OUTPUT_CHARS
+    header << "    Iteration      |  Time  |    Cuts     |     Objective value     |  Objective diff.   \r\n";
+    header << "     #: type       |  tot.  |   + | tot.  |    problem | line srch  |    abs. | rel.    \r\n";
+    header << "---------------------------------------------------------------------------------------\r\n";
+#else
     header << "    Iteration     │  Time  │    Cuts     │     Objective value     │  Objective diff.   \r\n";
     header << "     #: type      │  tot.  │   + | tot.  │    problem | line srch  │    abs. | rel.    \r\n";
     header << "╶─────────────────┴────────┴─────────────┴─────────────────────────┴──────────────────╴\r\n";
+#endif
 
     env->output->outputInfo(header.str());
 }
@@ -291,8 +319,14 @@ void Report::outputSolverHeader()
     std::stringstream header;
 
     header << "\r\n";
-    header << "╶ Supporting Hyperplane Optimization Toolkit (SHOT) "
-              "──────────────────────────────────────────────────────────────────╴\r\n";
+    header << "╶ Supporting Hyperplane Optimization Toolkit (SHOT) ";
+
+#ifdef SIMPLE_OUTPUT_CHARS
+    header << "-------------------------------------------------------------------\r\n";
+#else
+    header << "──────────────────────────────────────────────────────────────────╴\r\n";
+#endif
+
     header << "\r\n";
 
     header << " Andreas Lundell and Jan Kronqvist, Åbo Akademi University, Finland.\r\n";
@@ -335,9 +369,16 @@ void Report::outputOptionsReport()
     std::stringstream report;
 
     report << "\r\n";
-    report << "╶ Options "
-              "────────────────────────────────────────────────────────────────────────────────────────────────────────"
+    report << "╶ Options ";
+
+#ifdef SIMPLE_OUTPUT_CHARS
+    report << "--------------------------------------------------------------------------------------------------------"
+              "-----\r\n";
+#else
+    report << "────────────────────────────────────────────────────────────────────────────────────────────────────────"
               "────╴\r\n";
+#endif
+
     report << "\r\n";
 
     auto optionsFile = env->settings->getSetting<std::string>("OptionsFile", "Input");
@@ -535,9 +576,16 @@ void Report::outputModelingSystemHeader(ES_SourceFormat source, std::string file
 {
     std::stringstream report;
 
-    report << "╶ Modeling system "
-              "────────────────────────────────────────────────────────────────────────────────────────────────────╴"
+    report << "╶ Modeling system ";
+
+#ifdef SIMPLE_OUTPUT_CHARS
+    report << "-----------------------------------------------------------------------------------------------------"
               "\r\n";
+#else
+    report << "────────────────────────────────────────────────────────────────────────────────────────────────────╴"
+              "\r\n";
+#endif
+
     report << "\r\n";
 
     switch(source)
@@ -575,9 +623,16 @@ void Report::outputProblemInstanceReport()
 
     bool isReformulated = (env->problem == env->reformulatedProblem) ? false : true;
 
-    report << "\r\n╶ Problem instance "
-              "───────────────────────────────────────────────────────────────────────────────────────────────────╴"
+    report << "\r\n╶ Problem instance ";
+
+#ifdef SIMPLE_OUTPUT_CHARS
+    report << "----------------------------------------------------------------------------------------------------"
               "\r\n";
+#else
+    report << "───────────────────────────────────────────────────────────────────────────────────────────────────╴"
+              "\r\n";
+#endif
+
     report << "\r\n";
 
     if(isReformulated)
@@ -931,9 +986,16 @@ void Report::outputSolutionReport()
     std::stringstream report;
 
     report << "\r\n\r\n";
-    report << "╶ Solution report "
-              "────────────────────────────────────────────────────────────────────────────────────────────────────"
-              "╴\r\n";
+    report << "╶ Solution report ";
+
+#ifdef SIMPLE_OUTPUT_CHARS
+    report
+        << "-----------------------------------------------------------------------------------------------------\r\n";
+#else
+    report
+        << "────────────────────────────────────────────────────────────────────────────────────────────────────╴\r\n";
+#endif
+
     report << "\r\n";
 
     bool primalSolutionFound = env->results->hasPrimalSolution();
@@ -1273,8 +1335,14 @@ void Report::outputInteriorPointPreReport()
     std::stringstream report;
 
     report << "\r\n";
-    report << "╶ Interior point search "
-              "──────────────────────────────────────────────────────────────────────────────────────────────╴\r\n";
+    report << "╶ Interior point search ";
+
+#ifdef SIMPLE_OUTPUT_CHARS
+    report << "-----------------------------------------------------------------------------------------------\r\n";
+#else
+    report << "──────────────────────────────────────────────────────────────────────────────────────────────╴\r\n";
+#endif
+
     report << "\r\n";
 
     report << " Strategy selected:          ";

--- a/src/Report.cpp
+++ b/src/Report.cpp
@@ -318,12 +318,13 @@ void Report::outputSolverHeader()
 {
     std::stringstream header;
 
-    header << "\r\n";
-    header << "╶ Supporting Hyperplane Optimization Toolkit (SHOT) ";
-
 #ifdef SIMPLE_OUTPUT_CHARS
+    header << "\r\n";
+    header << "- Supporting Hyperplane Optimization Toolkit (SHOT) ";
     header << "-------------------------------------------------------------------\r\n";
 #else
+    header << "\r\n";
+    header << "╶ Supporting Hyperplane Optimization Toolkit (SHOT) ";
     header << "──────────────────────────────────────────────────────────────────╴\r\n";
 #endif
 
@@ -369,12 +370,13 @@ void Report::outputOptionsReport()
     std::stringstream report;
 
     report << "\r\n";
-    report << "╶ Options ";
 
 #ifdef SIMPLE_OUTPUT_CHARS
+    report << "- Options ";
     report << "--------------------------------------------------------------------------------------------------------"
               "-----\r\n";
 #else
+    report << "╶ Options ";
     report << "────────────────────────────────────────────────────────────────────────────────────────────────────────"
               "────╴\r\n";
 #endif
@@ -576,12 +578,12 @@ void Report::outputModelingSystemHeader(ES_SourceFormat source, std::string file
 {
     std::stringstream report;
 
-    report << "╶ Modeling system ";
-
 #ifdef SIMPLE_OUTPUT_CHARS
+    report << "- Modeling system ";
     report << "-----------------------------------------------------------------------------------------------------"
               "\r\n";
 #else
+    report << "╶ Modeling system ";
     report << "────────────────────────────────────────────────────────────────────────────────────────────────────╴"
               "\r\n";
 #endif
@@ -623,12 +625,12 @@ void Report::outputProblemInstanceReport()
 
     bool isReformulated = (env->problem == env->reformulatedProblem) ? false : true;
 
-    report << "\r\n╶ Problem instance ";
-
 #ifdef SIMPLE_OUTPUT_CHARS
+    report << "\r\n- Problem instance ";
     report << "----------------------------------------------------------------------------------------------------"
               "\r\n";
 #else
+    report << "\r\n╶ Problem instance ";
     report << "───────────────────────────────────────────────────────────────────────────────────────────────────╴"
               "\r\n";
 #endif
@@ -986,12 +988,13 @@ void Report::outputSolutionReport()
     std::stringstream report;
 
     report << "\r\n\r\n";
-    report << "╶ Solution report ";
 
 #ifdef SIMPLE_OUTPUT_CHARS
+    report << "- Solution report ";
     report
         << "-----------------------------------------------------------------------------------------------------\r\n";
 #else
+    report << "╶ Solution report ";
     report
         << "────────────────────────────────────────────────────────────────────────────────────────────────────╴\r\n";
 #endif
@@ -1334,12 +1337,13 @@ void Report::outputInteriorPointPreReport()
 {
     std::stringstream report;
 
-    report << "\r\n";
-    report << "╶ Interior point search ";
-
 #ifdef SIMPLE_OUTPUT_CHARS
+    report << "\r\n";
+    report << "- Interior point search ";
     report << "-----------------------------------------------------------------------------------------------\r\n";
 #else
+    report << "\r\n";
+    report << "╶ Interior point search ";
     report << "──────────────────────────────────────────────────────────────────────────────────────────────╴\r\n";
 #endif
 

--- a/src/SHOT.cpp
+++ b/src/SHOT.cpp
@@ -68,8 +68,13 @@ int main(int argc, char* argv[])
 
     if(cmdl["--help"])
     {
+#ifdef SIMPLE_OUTPUT_CHARS
+        env->output->outputInfo("-----------------------------------------------------------------------------------"
+                                "-----------------------------------\r\n");
+#else
         env->output->outputInfo("╶──────────────────────────────────────────────────────────────────────────────────"
                                 "───────────────────────────────────╴\r\n");
+#endif
 
         env->output->outputCritical(" Usage: SHOT PROBLEMFILE [ARGUMENTS] [OPTIONS]");
         env->output->outputCritical("");
@@ -238,7 +243,7 @@ int main(int argc, char* argv[])
             static_cast<E_LogLevel>(env->settings->getSetting<int>("File.LogLevel", "Output")));
     }
 
-    // Reads options specified in the command line arguments
+// Reads options specified in the command line arguments
 #if HAS_AMPL
     if(cmdl["--AMPL"])
     {
@@ -541,8 +546,13 @@ int main(int argc, char* argv[])
 
     env->report->outputSolutionReport();
 
+#ifdef SIMPLE_OUTPUT_CHARS
+    env->output->outputInfo("-----------------------------------------------------------------------------------"
+                            "-----------------------------------\r\n");
+#else
     env->output->outputInfo("╶──────────────────────────────────────────────────────────────────────────────────"
                             "───────────────────────────────────╴\r\n");
+#endif
 
     std::string osrl = solver.getResultsOSrL();
 

--- a/src/SolutionStrategy/SolutionStrategyMIQCQP.cpp
+++ b/src/SolutionStrategy/SolutionStrategyMIQCQP.cpp
@@ -174,9 +174,15 @@ bool SolutionStrategyMIQCQP::solveProblem()
 
     while(env->tasks->getNextTask(nextTask))
     {
+#ifdef SIMPLE_OUTPUT_CHARS
+        env->output->outputTrace("---- Started task:  " + nextTask->getType());
+        nextTask->run();
+        env->output->outputTrace("---- Finished task: " + nextTask->getType());
+#else
         env->output->outputTrace("┌─── Started task:  " + nextTask->getType());
         nextTask->run();
         env->output->outputTrace("└─── Finished task: " + nextTask->getType());
+#endif
     }
 
     return (true);

--- a/src/SolutionStrategy/SolutionStrategyMultiTree.cpp
+++ b/src/SolutionStrategy/SolutionStrategyMultiTree.cpp
@@ -321,9 +321,15 @@ bool SolutionStrategyMultiTree::solveProblem()
 
     while(env->tasks->getNextTask(nextTask))
     {
+#ifdef SIMPLE_OUTPUT_CHARS
+        env->output->outputTrace("---- Started task:  " + nextTask->getType());
+        nextTask->run();
+        env->output->outputTrace("---- Finished task: " + nextTask->getType());
+#else
         env->output->outputTrace("┌─── Started task:  " + nextTask->getType());
         nextTask->run();
         env->output->outputTrace("└─── Finished task: " + nextTask->getType());
+#endif
     }
 
     return (true);

--- a/src/SolutionStrategy/SolutionStrategyNLP.cpp
+++ b/src/SolutionStrategy/SolutionStrategyNLP.cpp
@@ -224,9 +224,15 @@ bool SolutionStrategyNLP::solveProblem()
 
     while(env->tasks->getNextTask(nextTask))
     {
+#ifdef SIMPLE_OUTPUT_CHARS
+        env->output->outputTrace("---- Started task:  " + nextTask->getType());
+        nextTask->run();
+        env->output->outputTrace("---- Finished task: " + nextTask->getType());
+#else
         env->output->outputTrace("┌─── Started task:  " + nextTask->getType());
         nextTask->run();
         env->output->outputTrace("└─── Finished task: " + nextTask->getType());
+#endif
     }
 
     return (true);

--- a/src/SolutionStrategy/SolutionStrategySingleTree.cpp
+++ b/src/SolutionStrategy/SolutionStrategySingleTree.cpp
@@ -287,9 +287,15 @@ bool SolutionStrategySingleTree::solveProblem()
 
     while(env->tasks->getNextTask(nextTask))
     {
+#ifdef SIMPLE_OUTPUT_CHARS
+        env->output->outputTrace("---- Started task:  " + nextTask->getType());
+        nextTask->run();
+        env->output->outputTrace("---- Finished task: " + nextTask->getType());
+#else
         env->output->outputTrace("┌─── Started task:  " + nextTask->getType());
         nextTask->run();
         env->output->outputTrace("└─── Finished task: " + nextTask->getType());
+#endif
     }
 
     return (true);

--- a/src/Tasks/TaskSequential.cpp
+++ b/src/Tasks/TaskSequential.cpp
@@ -30,9 +30,15 @@ void TaskSequential::run()
 {
     for(auto& T : m_tasks)
     {
+#ifdef SIMPLE_OUTPUT_CHARS
+        env->output->outputTrace("---- Started task:  " + T->getType());
+        T->run();
+        env->output->outputTrace("---- Finished task: " + T->getType());
+#else
         env->output->outputTrace("┌─── Started task:  " + T->getType());
         T->run();
         env->output->outputTrace("└─── Finished task: " + T->getType());
+#endif
     }
 }
 


### PR DESCRIPTION
This should fix the problem with strange characters in MinGW termininals. Currently it is activated for MinGW, but perhaps it should be for MSVC as well? 