### PR TITLE
Streamline how temp directories are created

### DIFF
--- a/src/ModelingSystem/ModelingSystemGAMS.cpp
+++ b/src/ModelingSystem/ModelingSystemGAMS.cpp
@@ -129,9 +129,6 @@ void ModelingSystemGAMS::updateSettings(SettingsPtr settings)
 
         env->settings->updateSetting("MIP.NumberOfThreads", "Dual", gevThreads(modelingEnvironment));
 
-        char buf[GMS_SSSIZE];
-        env->settings->updateSetting("Debug.Path", "Output", std::string(gevGetStrOpt(modelingEnvironment, gevNameScrDir, buf)));
-
         env->output->outputDebug("Time limit set to "
             + Utilities::toString(env->settings->getSetting<double>("TimeLimit", "Termination")) + " by GAMS");
         env->output->outputDebug("Iteration limit set to "
@@ -144,8 +141,6 @@ void ModelingSystemGAMS::updateSettings(SettingsPtr settings)
             + " by GAMS");
         env->output->outputDebug("MIP number of threads set to "
             + Utilities::toString(env->settings->getSetting<int>("MIP.NumberOfThreads", "Dual")) + " by GAMS");
-        env->output->outputDebug("Debug path set to "
-            + env->settings->getSetting<std::string>("Debug.Path", "Output") + " by GAMS");
     }
 
     if(gmoOptFile(modelingObject) > 0) // GAMS provides an option file

--- a/src/SHOT.cpp
+++ b/src/SHOT.cpp
@@ -630,12 +630,12 @@ int main(int argc, char* argv[])
     }
 
     env->results = NULL;
-    env->settings = NULL;
     env->problem = NULL;
     env->reformulatedProblem = NULL;
     env->modelingSystem = NULL;
     env->dualSolver = NULL;
     env->primalSolver = NULL;
+    env->settings = NULL;
     env->output = NULL;
     env->report = NULL;
     env->tasks = NULL;

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -19,8 +19,6 @@
 #include "Timing.h"
 #include "Utilities.h"
 
-#include <random>
-
 #ifdef HAS_GAMS
 #include "ModelingSystem/ModelingSystemGAMS.h"
 #endif
@@ -216,40 +214,17 @@ bool Solver::setProblem(std::string fileName)
     env->settings->updateSetting("ProblemFile", "Input", fs::filesystem::absolute(problemFile).string());
 
     // Sets the debug path if not already set
-    if(env->settings->getSetting<std::string>("Debug.Path", "Output") == "")
+    if(env->settings->getSetting<bool>("Debug.Enable", "Output")
+        && env->settings->getSetting<std::string>("Debug.Path", "Output") == "")
     {
-        auto tmpDirPath = fs::filesystem::temp_directory_path();
-        int i = 0;
-
-        int maxTries = 1000;
-        std::random_device dev;
-        std::mt19937 prng(dev());
-        std::uniform_int_distribution<uint64_t> rand(0);
-        fs::filesystem::path path;
-
-        while(true)
+        if(auto debugPath = Utilities::createTemporaryDirectory("SHOT_debug_"); debugPath == "")
         {
-            std::stringstream ss;
-            ss << "SHOT_" << std::hex << rand(prng);
-            path = tmpDirPath / ss.str();
-
-            if(fs::filesystem::create_directory(path))
-            // True if the directory was created.
-            {
-                fs::filesystem::path debugPath(path);
-
-                env->settings->updateSetting("Debug.Path", "Output", debugPath.string());
-                break;
-            }
-            if(i == maxTries)
-            {
-                env->output->outputError(
-                    fmt::format("Could not create debug directory in folder \"{}\". Try emptying the directory.",
-                        tmpDirPath.string()));
-                return (false);
-            }
-
-            i++;
+            env->output->outputError("Could not create debug directory.");
+            return (false);
+        }
+        else
+        {
+            env->settings->updateSetting("Debug.Path", "Output", debugPath);
         }
     }
 

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -381,40 +381,17 @@ bool Solver::setProblem(SHOT::ProblemPtr problem, SHOT::ModelingSystemPtr modeli
     env->settings->updateSetting("ProblemName", "Input", problem->name);
 
     // Sets the debug path if not already set
-    if(env->settings->getSetting<std::string>("Debug.Path", "Output") == "")
+    if(env->settings->getSetting<bool>("Debug.Enable", "Output")
+        && env->settings->getSetting<std::string>("Debug.Path", "Output") == "")
     {
-        auto tmpDirPath = fs::filesystem::temp_directory_path();
-        int i = 0;
-
-        int maxTries = 1000;
-        std::random_device dev;
-        std::mt19937 prng(dev());
-        std::uniform_int_distribution<uint64_t> rand(0);
-        fs::filesystem::path path;
-
-        while(true)
+        if(auto debugPath = Utilities::createTemporaryDirectory("SHOT_debug_"); debugPath == "")
         {
-            std::stringstream ss;
-            ss << "SHOT_" << std::hex << rand(prng);
-            path = tmpDirPath / ss.str();
-
-            if(fs::filesystem::create_directory(path))
-            // True if the directory was created.
-            {
-                fs::filesystem::path debugPath(path);
-
-                env->settings->updateSetting("Debug.Path", "Output", debugPath.string());
-                break;
-            }
-            if(i == maxTries)
-            {
-                env->output->outputError(
-                    fmt::format("Could not create debug directory in folder \"{}\". Try emptying the directory.",
-                        tmpDirPath.string()));
-                return (false);
-            }
-
-            i++;
+            env->output->outputError("Could not create debug directory.");
+            return (false);
+        }
+        else
+        {
+            env->settings->updateSetting("Debug.Path", "Output", debugPath);
         }
     }
 
@@ -1552,10 +1529,10 @@ void Solver::initializeDebugMode()
     if(env->settings->getSetting<std::string>("ProblemFile", "Input") != "")
     {
         fs::filesystem::path source(
-           fs::filesystem::canonical(env->settings->getSetting<std::string>("ProblemFile", "Input")));
+            fs::filesystem::canonical(env->settings->getSetting<std::string>("ProblemFile", "Input")));
 
         fs::filesystem::copy_file(
-           source.string(), (debugDir / source.filename()).string(), fs::filesystem::copy_options::overwrite_existing);
+            source.string(), (debugDir / source.filename()).string(), fs::filesystem::copy_options::overwrite_existing);
     }
 }
 

--- a/src/Utilities.cpp
+++ b/src/Utilities.cpp
@@ -22,6 +22,16 @@
 
 #include "spdlog/fmt/fmt.h"
 
+#ifdef HAS_STD_FILESYSTEM
+#include <filesystem>
+namespace fs = std;
+#endif
+
+#ifdef HAS_STD_EXPERIMENTAL_FILESYSTEM
+#include <experimental/filesystem>
+namespace fs = std::experimental;
+#endif
+
 namespace SHOT::Utilities
 {
 
@@ -737,6 +747,43 @@ std::vector<std::string> splitStringByCharacter(const std::string& source, char 
         result.push_back(line);
 
     return result;
+}
+
+std::string createTemporaryDirectory(std::string filePrefix, std::string folder)
+{
+    auto tmpDirPath = fs::filesystem::temp_directory_path();
+    int i = 0;
+
+    int maxTries = 1000;
+    std::random_device dev;
+    std::mt19937 prng(dev());
+    std::uniform_int_distribution<uint64_t> rand(0);
+    fs::filesystem::path path;
+
+    while(true)
+    {
+        std::stringstream ss;
+        ss << filePrefix << std::hex << rand(prng);
+
+        if(folder == "")
+            path = tmpDirPath / ss.str();
+        else
+            path = fs::filesystem::path(folder) / ss.str();
+
+        if(fs::filesystem::create_directory(path))
+        // True if the directory was created.
+        {
+            break;
+        }
+        if(i == maxTries)
+        {
+            return ("");
+        }
+
+        i++;
+    }
+
+    return (path.string());
 }
 
 } // namespace SHOT::Utilities

--- a/src/Utilities.h
+++ b/src/Utilities.h
@@ -131,4 +131,8 @@ E_Convexity combineConvexity(const E_Convexity first, const E_Convexity second);
 E_Monotonicity combineMonotonicity(const E_Monotonicity first, const E_Monotonicity second);
 
 std::vector<std::string> splitStringByCharacter(const std::string& source, char character);
+
+// Creates a unique directory in the specified folder (or system temporary folder if folder is an empty string).
+// Returns an empty string if the directory could not be created.
+std::string createTemporaryDirectory(std::string filePrefix, std::string folder = "");
 } // namespace SHOT::Utilities


### PR DESCRIPTION
- Refactored the code to create temporary directories to the `Utilities`-class.
- Used this functionality in `Solver.cpp` (two places) and ModelingSystemGAMS.cpp`.
- Logic:
  - If the debug mode is not activated no debug directory is obviously created. A GAMS temporary directory is created as `/tmp/SHOT_GAMS_*****/`. This directory is deleted when SHOT exits.
  - If the debug mode is activated but the debug directory is not specified, a directory `/tmp/SHOT_debug_*****/` is used. In this directory a directory `SHOT_GAMS_****`  is created where the GAMS temporary files are put. These directories are not removed on exit.

This works well when using SHOT directly on a GAMS problem file, but does it work when called from GAMS (espcially after https://github.com/coin-or/SHOT/commit/06e768279fec30b796737a013993b36ecb7c8843)?

