### PR TITLE
add Ipopt Journal implementation that directs Ipopt output through SHOT

### DIFF
--- a/src/NLPSolver/NLPSolverGAMS.cpp
+++ b/src/NLPSolver/NLPSolverGAMS.cpp
@@ -84,7 +84,6 @@ NLPSolverGAMS::NLPSolverGAMS(EnvironmentPtr envPtr, gmoHandle_t modelingObject, 
         std::transform(selectedNLPSolver.begin(), selectedNLPSolver.end(), selectedNLPSolver.begin(), ::toupper);
     }
 
-    // TODO: showlog seems to have no effect...
     showlog = env->settings->getSetting<bool>("Console.PrimalSolver.Show", "Output");
 }
 

--- a/src/NLPSolver/NLPSolverGAMS.cpp
+++ b/src/NLPSolver/NLPSolverGAMS.cpp
@@ -85,7 +85,7 @@ NLPSolverGAMS::NLPSolverGAMS(EnvironmentPtr envPtr, gmoHandle_t modelingObject, 
     }
 
     // TODO: showlog seems to have no effect...
-    showlog = env->settings->getSetting<bool>("Console.GAMS.Show", "Output");
+    showlog = env->settings->getSetting<bool>("Console.PrimalSolver.Show", "Output");
 }
 
 NLPSolverGAMS::~NLPSolverGAMS() = default;

--- a/src/NLPSolver/NLPSolverIpoptBase.cpp
+++ b/src/NLPSolver/NLPSolverIpoptBase.cpp
@@ -10,6 +10,8 @@
 
 #include "NLPSolverIpoptBase.h"
 
+#include <cstdio>
+
 #include "../Output.h"
 #include "../Settings.h"
 #include "../Utilities.h"
@@ -18,6 +20,54 @@ namespace SHOT
 {
 
 using namespace Ipopt;
+
+void SHOTJournal::PrintImpl(
+   Ipopt::EJournalCategory category,
+   Ipopt::EJournalLevel    level,
+   const char*             str
+)
+{
+    auto lines = Utilities::splitStringByCharacter(str, '\n');
+
+    for(auto const line : lines)
+        env->output->outputInfo(fmt::format("      | {} ", line));
+}
+
+void SHOTJournal::PrintfImpl(
+   Ipopt::EJournalCategory category,
+   Ipopt::EJournalLevel    level,
+   const char*             pformat,
+   va_list                 ap
+)
+{
+    // append to output buffer
+    int rc = std::vsnprintf(outBuf + outBufPos, sizeof(outBuf) - outBufPos, pformat, ap);
+
+    if( rc < 0 ) // ignore error
+        return;
+
+    outBufPos += rc;
+
+    // if output buffer terminates with newline or is almost full, then print
+    if( (outBufPos > 0 && outBuf[outBufPos-1] == '\n') || outBufPos > sizeof(outBuf) - 100 )
+    {
+        PrintImpl(category, level, outBuf);
+        outBufPos = 0;
+    }
+}
+
+void SHOTJournal::FlushBufferImpl()
+{
+    if( outBufPos > 0 )
+    {
+        // just make up a category and level, as not used in PrintImpl anyway
+        PrintImpl(J_LAST_CATEGORY, J_ALL, outBuf);
+        outBufPos = 0;
+    }
+
+    env->output->flush();
+}
+
 
 IpoptProblem::IpoptProblem(EnvironmentPtr envPtr, ProblemPtr problem) : env(envPtr), sourceProblem(problem) {}
 

--- a/src/NLPSolver/NLPSolverIpoptBase.cpp
+++ b/src/NLPSolver/NLPSolverIpoptBase.cpp
@@ -21,11 +21,7 @@ namespace SHOT
 
 using namespace Ipopt;
 
-void SHOTJournal::PrintImpl(
-   Ipopt::EJournalCategory category,
-   Ipopt::EJournalLevel    level,
-   const char*             str
-)
+void SHOTIpoptJournal::PrintImpl(Ipopt::EJournalCategory category, Ipopt::EJournalLevel level, const char* str)
 {
     auto lines = Utilities::splitStringByCharacter(str, '\n');
 
@@ -33,32 +29,28 @@ void SHOTJournal::PrintImpl(
         env->output->outputInfo(fmt::format("      | {} ", line));
 }
 
-void SHOTJournal::PrintfImpl(
-   Ipopt::EJournalCategory category,
-   Ipopt::EJournalLevel    level,
-   const char*             pformat,
-   va_list                 ap
-)
+void SHOTIpoptJournal::PrintfImpl(
+    Ipopt::EJournalCategory category, Ipopt::EJournalLevel level, const char* pformat, va_list ap)
 {
     // append to output buffer
     int rc = std::vsnprintf(outBuf + outBufPos, sizeof(outBuf) - outBufPos, pformat, ap);
 
-    if( rc < 0 ) // ignore error
+    if(rc < 0) // ignore error
         return;
 
     outBufPos += rc;
 
     // if output buffer terminates with newline or is almost full, then print
-    if( (outBufPos > 0 && outBuf[outBufPos-1] == '\n') || outBufPos > sizeof(outBuf) - 100 )
+    if((outBufPos > 0 && outBuf[outBufPos - 1] == '\n') || outBufPos > sizeof(outBuf) - 100)
     {
         PrintImpl(category, level, outBuf);
         outBufPos = 0;
     }
 }
 
-void SHOTJournal::FlushBufferImpl()
+void SHOTIpoptJournal::FlushBufferImpl()
 {
-    if( outBufPos > 0 )
+    if(outBufPos > 0)
     {
         // just make up a category and level, as not used in PrintImpl anyway
         PrintImpl(J_LAST_CATEGORY, J_ALL, outBuf);
@@ -67,7 +59,6 @@ void SHOTJournal::FlushBufferImpl()
 
     env->output->flush();
 }
-
 
 IpoptProblem::IpoptProblem(EnvironmentPtr envPtr, ProblemPtr problem) : env(envPtr), sourceProblem(problem) {}
 

--- a/src/NLPSolver/NLPSolverIpoptBase.cpp
+++ b/src/NLPSolver/NLPSolverIpoptBase.cpp
@@ -21,7 +21,7 @@ namespace SHOT
 
 using namespace Ipopt;
 
-void SHOTIpoptJournal::PrintImpl(Ipopt::EJournalCategory category, Ipopt::EJournalLevel level, const char* str)
+void IpoptJournal::PrintImpl(Ipopt::EJournalCategory category, Ipopt::EJournalLevel level, const char* str)
 {
     auto lines = Utilities::splitStringByCharacter(str, '\n');
 
@@ -57,7 +57,7 @@ void SHOTIpoptJournal::PrintImpl(Ipopt::EJournalCategory category, Ipopt::EJourn
     }
 }
 
-void SHOTIpoptJournal::PrintfImpl(
+void IpoptJournal::PrintfImpl(
     Ipopt::EJournalCategory category, Ipopt::EJournalLevel level, const char* pformat, va_list ap)
 {
     if(level == Ipopt::EJournalLevel::J_NONE)
@@ -79,7 +79,7 @@ void SHOTIpoptJournal::PrintfImpl(
     }
 }
 
-void SHOTIpoptJournal::FlushBufferImpl()
+void IpoptJournal::FlushBufferImpl()
 {
     if(outBufPos > 0)
     {

--- a/src/NLPSolver/NLPSolverIpoptBase.h
+++ b/src/NLPSolver/NLPSolverIpoptBase.h
@@ -23,7 +23,7 @@ namespace SHOT
 class NLPSolverIpoptBase;
 
 // An Ipopt Journal implementation that uses the SHOT routines for output */
-class SHOTIpoptJournal : public Ipopt::Journal
+class IpoptJournal : public Ipopt::Journal
 {
 private:
     EnvironmentPtr env;
@@ -31,7 +31,7 @@ private:
     int outBufPos = 0;
 
 public:
-    SHOTIpoptJournal(EnvironmentPtr envPtr, /**< SHOT environment */
+    IpoptJournal(EnvironmentPtr envPtr, /**< SHOT environment */
         const char* name, /**< journalist name */
         Ipopt::EJournalLevel default_level /**< default journal level */
         )

--- a/src/NLPSolver/NLPSolverIpoptBase.h
+++ b/src/NLPSolver/NLPSolverIpoptBase.h
@@ -23,40 +23,29 @@ namespace SHOT
 class NLPSolverIpoptBase;
 
 // An Ipopt Journal implementation that uses the SHOT routines for output */
-class SHOTJournal : public Ipopt::Journal
+class SHOTIpoptJournal : public Ipopt::Journal
 {
 private:
-   EnvironmentPtr env;
-   char outBuf[10000];
-   int outBufPos = 0;
+    EnvironmentPtr env;
+    char outBuf[10000];
+    int outBufPos = 0;
 
 public:
-   SHOTJournal(
-      EnvironmentPtr       envPtr,           /**< SHOT environment */
-      const char*          name,             /**< journalist name */
-      Ipopt::EJournalLevel default_level     /**< default journal level */
-   )
-   : Ipopt::Journal(name, default_level),
-     env(envPtr)
-   { }
+    SHOTIpoptJournal(EnvironmentPtr envPtr, /**< SHOT environment */
+        const char* name, /**< journalist name */
+        Ipopt::EJournalLevel default_level /**< default journal level */
+        )
+        : Ipopt::Journal(name, default_level), env(envPtr)
+    {
+    }
 
 protected:
-   void PrintImpl(
-      Ipopt::EJournalCategory category,
-      Ipopt::EJournalLevel    level,
-      const char*             str
-   );
+    void PrintImpl(Ipopt::EJournalCategory category, Ipopt::EJournalLevel level, const char* str);
 
-   void PrintfImpl(
-      Ipopt::EJournalCategory category,
-      Ipopt::EJournalLevel    level,
-      const char*             pformat,
-      va_list                 ap
-   );
+    void PrintfImpl(Ipopt::EJournalCategory category, Ipopt::EJournalLevel level, const char* pformat, va_list ap);
 
-   void FlushBufferImpl();
+    void FlushBufferImpl();
 };
-
 
 // The following class is adapted from COIN-OR Optimization Services Ipopt interface
 class IpoptProblem : public Ipopt::TNLP

--- a/src/NLPSolver/NLPSolverIpoptBase.h
+++ b/src/NLPSolver/NLPSolverIpoptBase.h
@@ -13,6 +13,7 @@
 
 #include "IpTNLP.hpp"
 #include "IpIpoptApplication.hpp"
+#include "IpJournalist.hpp"
 
 #include "../Model/Problem.h"
 
@@ -20,6 +21,42 @@ namespace SHOT
 {
 
 class NLPSolverIpoptBase;
+
+// An Ipopt Journal implementation that uses the SHOT routines for output */
+class SHOTJournal : public Ipopt::Journal
+{
+private:
+   EnvironmentPtr env;
+   char outBuf[10000];
+   int outBufPos = 0;
+
+public:
+   SHOTJournal(
+      EnvironmentPtr       envPtr,           /**< SHOT environment */
+      const char*          name,             /**< journalist name */
+      Ipopt::EJournalLevel default_level     /**< default journal level */
+   )
+   : Ipopt::Journal(name, default_level),
+     env(envPtr)
+   { }
+
+protected:
+   void PrintImpl(
+      Ipopt::EJournalCategory category,
+      Ipopt::EJournalLevel    level,
+      const char*             str
+   );
+
+   void PrintfImpl(
+      Ipopt::EJournalCategory category,
+      Ipopt::EJournalLevel    level,
+      const char*             pformat,
+      va_list                 ap
+   );
+
+   void FlushBufferImpl();
+};
+
 
 // The following class is adapted from COIN-OR Optimization Services Ipopt interface
 class IpoptProblem : public Ipopt::TNLP

--- a/src/NLPSolver/NLPSolverIpoptRelaxed.cpp
+++ b/src/NLPSolver/NLPSolverIpoptRelaxed.cpp
@@ -29,10 +29,10 @@ NLPSolverIpoptRelaxed::NLPSolverIpoptRelaxed(EnvironmentPtr envPtr, ProblemPtr s
     ipoptProblem = new IpoptProblem(env, sourceProblem);
     ipoptApplication = new Ipopt::IpoptApplication(false);
 
-    Ipopt::SmartPtr<Ipopt::Journal> jrnl = new SHOTJournal(envPtr, "console", Ipopt::J_ALL);
+    Ipopt::SmartPtr<Ipopt::Journal> jrnl = new SHOTIpoptJournal(envPtr, "console", Ipopt::J_ALL);
     jrnl->SetPrintLevel(Ipopt::J_DBG, Ipopt::J_NONE);
-    if( !ipoptApplication->Jnlst()->AddJournal(jrnl) )
-        envPtr->output->outputError("        Failed to register SHOTJournal for IPOPT output.");
+    if(!ipoptApplication->Jnlst()->AddJournal(jrnl))
+        envPtr->output->outputError("        Failed to register SHOTIpoptJournal for IPOPT output.");
 
     setInitialSettings();
 

--- a/src/NLPSolver/NLPSolverIpoptRelaxed.cpp
+++ b/src/NLPSolver/NLPSolverIpoptRelaxed.cpp
@@ -29,10 +29,10 @@ NLPSolverIpoptRelaxed::NLPSolverIpoptRelaxed(EnvironmentPtr envPtr, ProblemPtr s
     ipoptProblem = new IpoptProblem(env, sourceProblem);
     ipoptApplication = new Ipopt::IpoptApplication(false);
 
-    Ipopt::SmartPtr<Ipopt::Journal> jrnl = new SHOTIpoptJournal(envPtr, "console", Ipopt::J_ALL);
+    Ipopt::SmartPtr<Ipopt::Journal> jrnl = new IpoptJournal(envPtr, "console", Ipopt::J_ALL);
     jrnl->SetPrintLevel(Ipopt::J_DBG, Ipopt::J_NONE);
     if(!ipoptApplication->Jnlst()->AddJournal(jrnl))
-        envPtr->output->outputError("        Failed to register SHOTIpoptJournal for IPOPT output.");
+        envPtr->output->outputError("        Failed to register IpoptJournal for IPOPT output.");
 
     setInitialSettings();
 

--- a/src/NLPSolver/NLPSolverIpoptRelaxed.cpp
+++ b/src/NLPSolver/NLPSolverIpoptRelaxed.cpp
@@ -27,7 +27,12 @@ NLPSolverIpoptRelaxed::NLPSolverIpoptRelaxed(EnvironmentPtr envPtr, ProblemPtr s
     updateSettings();
 
     ipoptProblem = new IpoptProblem(env, sourceProblem);
-    ipoptApplication = new Ipopt::IpoptApplication();
+    ipoptApplication = new Ipopt::IpoptApplication(false);
+
+    Ipopt::SmartPtr<Ipopt::Journal> jrnl = new SHOTJournal(envPtr, "console", Ipopt::J_ALL);
+    jrnl->SetPrintLevel(Ipopt::J_DBG, Ipopt::J_NONE);
+    if( !ipoptApplication->Jnlst()->AddJournal(jrnl) )
+        envPtr->output->outputError("        Failed to register SHOTJournal for IPOPT output.");
 
     setInitialSettings();
 

--- a/src/Output.h
+++ b/src/Output.h
@@ -40,6 +40,8 @@ public:
 
     void setFileSink(std::string filename);
 
+    void flush() { logger->flush(); }
+
 private:
     std::shared_ptr<spdlog::sinks::sink> consoleSink;
     std::shared_ptr<spdlog::sinks::basic_file_sink_st> fileSink;

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -1043,12 +1043,8 @@ void Solver::initializeSettings()
     enumLogLevel.clear();
 
     env->settings->createSetting("Console.DualSolver.Show", "Output", false, "Show output from dual solver on console");
-
-#ifdef HAS_GAMS
-
-    env->settings->createSetting("Console.GAMS.Show", "Output", false, "Show GAMS output on console");
-
-#endif
+    env->settings->createSetting(
+        "Console.PrimalSolver.Show", "Output", false, "Show output from primal solver on console");
 
     VectorString enumIterationDetail;
     enumIterationDetail.push_back("Full");
@@ -1711,6 +1707,11 @@ void Solver::verifySettings()
 
     // Set correct iteration detail output when showing dual solver output
     if(env->settings->getSetting<bool>("Console.DualSolver.Show", "Output"))
+        env->settings->updateSetting(
+            "Console.Iteration.Detail", "Output", static_cast<int>(ES_IterationOutputDetail::Full));
+
+    // Set correct iteration detail output when showing primal solver output
+    if(env->settings->getSetting<bool>("Console.PrimalSolver.Show", "Output"))
         env->settings->updateSetting(
             "Console.Iteration.Detail", "Output", static_cast<int>(ES_IterationOutputDetail::Full));
 }


### PR DESCRIPTION
This makes sure that Ipopt output is directed through the SHOT Output instead of going to console. Even with default settings, strong warnings (like something about feasibiliy restoration failing) were going to stdout.

If you want to add this, you probably want to reformat things, etc.