### PR TITLE
Various bugfixes

### DIFF
--- a/src/DualSolver.cpp
+++ b/src/DualSolver.cpp
@@ -223,6 +223,11 @@ void DualSolver::addGeneratedHyperplane(const Hyperplane& hyperplane)
 
 bool DualSolver::hasHyperplaneBeenAdded(double hash, int constraintIndex)
 {
+    // Cuts added as lazy might not actually always be added (e.g. in different threads), thus we have to allow them to
+    // be added again
+    if(env->settings->getSetting<int>("TreeStrategy", "Dual") == static_cast<int>(ES_TreeStrategy::SingleTree))
+        return false;
+
     for(auto& H : generatedHyperplanes)
     {
         if(H.source == E_HyperplaneSource::ObjectiveRootsearch && constraintIndex == -1

--- a/src/Enums.h
+++ b/src/Enums.h
@@ -20,6 +20,7 @@ enum class E_AuxiliaryVariableType
     NonlinearExpressionPartitioning, // From reformulating nonlinear terms as constraints
     MonomialTermsPartitioning, // From reformulating monoial terms as constraints
     SignomialTermsPartitioning, // From reformulating signomial terms as constraints
+    SquareTermsPartitioning, // From reformulating sums of square terms
     ContinuousBilinear, // From linearizing a bilinear term x1 * x2 where x1 and x2 are real
     BinaryBilinear, // From linearizing a bilinear term b1 * b2 where b1 and b2 are binary
     BinaryContinuousBilinear, // From linearizing a bilinear term b1 * x2 where b1 is binary and x2 is continuous

--- a/src/Enums.h
+++ b/src/Enums.h
@@ -309,8 +309,7 @@ enum class ES_RootsearchConstraintStrategy
 enum class ES_RootsearchMethod
 {
     BoostTOMS748,
-    BoostBisection,
-    Bisection
+    BoostBisection
 };
 
 enum class ES_MIPSolver

--- a/src/MIPSolver/MIPSolverCbc.cpp
+++ b/src/MIPSolver/MIPSolverCbc.cpp
@@ -258,6 +258,7 @@ void MIPSolverCbc::initializeSolverSettings()
     osiInterface->setDblParam(
         OsiPrimalTolerance, env->settings->getSetting<double>("Tolerance.LinearConstraint", "Primal"));
     cbcModel->setIntegerTolerance(env->settings->getSetting<double>("Tolerance.Integer", "Primal"));
+    osiInterface->setDblParam(OsiDualTolerance, env->settings->getSetting<double>("MIP.OptimalityTolerance", "Dual"));
 
     // Adds a user-provided node limit
     if(auto nodeLimit = env->settings->getSetting<double>("MIP.NodeLimit", "Dual"); nodeLimit > 0)

--- a/src/MIPSolver/MIPSolverCplex.cpp
+++ b/src/MIPSolver/MIPSolverCplex.cpp
@@ -377,6 +377,8 @@ void MIPSolverCplex::initializeSolverSettings()
             env->settings->getSetting<double>("Tolerance.LinearConstraint", "Primal"));
         cplexInstance.setParam(IloCplex::Param::MIP::Tolerances::Integrality,
             env->settings->getSetting<double>("Tolerance.Integer", "Primal"));
+        cplexInstance.setParam(IloCplex::Param::Simplex::Tolerances::Optimality,
+            env->settings->getSetting<double>("MIP.OptimalityTolerance", "Dual"));
 
         // Adds a user-provided node limit
         if(auto nodeLimit = env->settings->getSetting<double>("MIP.NodeLimit", "Dual"); nodeLimit > 0)

--- a/src/MIPSolver/MIPSolverCplex.cpp
+++ b/src/MIPSolver/MIPSolverCplex.cpp
@@ -527,7 +527,7 @@ void MIPSolverCplex::activateDiscreteVariables(bool activate)
 
         if(activate)
         {
-            env->output->outputDebug(" Activating MIP strategy.");
+            env->output->outputDebug("        Activating MIP strategy.");
 
             for(int i = 0; i < numberOfVariables; i++)
             {

--- a/src/MIPSolver/MIPSolverCplexSingleTreeLegacy.cpp
+++ b/src/MIPSolver/MIPSolverCplexSingleTreeLegacy.cpp
@@ -723,9 +723,6 @@ E_ProblemSolutionStatus MIPSolverCplexSingleTreeLegacy::solveProblem()
             }
         }
 
-        // Fixes a deadlock bug in Cplex 12.7 and 12.8
-        cplexEnv.setNormalizer(false);
-
         cplexInstance.solve();
         MIPSolutionStatus = getSolutionStatus();
 

--- a/src/MIPSolver/MIPSolverCplexSingleTreeLegacy.cpp
+++ b/src/MIPSolver/MIPSolverCplexSingleTreeLegacy.cpp
@@ -576,7 +576,7 @@ bool CtCallbackI::createHyperplane(Hyperplane hyperplane)
         }
         else
         {
-            add(tmpRange, IloCplex::CutManagement::UseCutPurge).end();
+            add(tmpRange, IloCplex::CutManagement::UseCutForce).end();
         }
 
         std::string identifier = env->dualSolver->MIPSolver->getConstraintIdentifier(hyperplane.source);

--- a/src/MIPSolver/MIPSolverGurobi.cpp
+++ b/src/MIPSolver/MIPSolverGurobi.cpp
@@ -380,6 +380,8 @@ void MIPSolverGurobi::initializeSolverSettings()
             GRB_DoubleParam_FeasibilityTol, env->settings->getSetting<double>("Tolerance.LinearConstraint", "Primal"));
         gurobiModel->getEnv().set(
             GRB_DoubleParam_IntFeasTol, env->settings->getSetting<double>("Tolerance.Integer", "Primal"));
+        gurobiModel->getEnv().set(
+            GRB_DoubleParam_OptimalityTol, env->settings->getSetting<double>("MIP.OptimalityTolerance", "Dual"));
 
         // Add a user-provided node limit
         if(auto nodeLimit = env->settings->getSetting<double>("MIP.NodeLimit", "Dual"); nodeLimit > 0)

--- a/src/Model/Problem.cpp
+++ b/src/Model/Problem.cpp
@@ -1280,6 +1280,34 @@ std::optional<NumericConstraintValue> Problem::getMostDeviatingNumericConstraint
     return (this->getMostDeviatingNumericConstraint(point, numericConstraints));
 }
 
+std::optional<NumericConstraintValue> Problem::getMostDeviatingNonlinearOrQuadraticConstraint(const VectorDouble& point)
+{
+    NumericConstraintValue constraintValue;
+
+    if(properties.numberOfNonlinearConstraints > 0)
+    {
+        constraintValue = getMaxNumericConstraintValue(point, nonlinearConstraints);
+
+        if(properties.numberOfQuadraticConstraints > 0)
+        {
+            auto quadConstraintValue = getMaxNumericConstraintValue(point, quadraticConstraints);
+
+            if(quadConstraintValue.error > constraintValue.error)
+                constraintValue = quadConstraintValue;
+        }
+    }
+    else if(properties.numberOfQuadraticConstraints > 0)
+    {
+        constraintValue = getMaxNumericConstraintValue(point, quadraticConstraints);
+    }
+    else
+    {
+        throw ConstraintNotFoundException("There are no quadratic or nonlinear constraints.");
+    }
+
+    return (constraintValue);
+}
+
 std::optional<NumericConstraintValue> Problem::getMostDeviatingNonlinearConstraint(const VectorDouble& point)
 {
     return (this->getMostDeviatingNumericConstraint(point, nonlinearConstraints));

--- a/src/Model/Problem.cpp
+++ b/src/Model/Problem.cpp
@@ -1282,7 +1282,7 @@ std::optional<NumericConstraintValue> Problem::getMostDeviatingNumericConstraint
 
 std::optional<NumericConstraintValue> Problem::getMostDeviatingNonlinearOrQuadraticConstraint(const VectorDouble& point)
 {
-    NumericConstraintValue constraintValue;
+    std::optional<NumericConstraintValue> constraintValue;
 
     if(properties.numberOfNonlinearConstraints > 0)
     {
@@ -1292,17 +1292,13 @@ std::optional<NumericConstraintValue> Problem::getMostDeviatingNonlinearOrQuadra
         {
             auto quadConstraintValue = getMaxNumericConstraintValue(point, quadraticConstraints);
 
-            if(quadConstraintValue.error > constraintValue.error)
+            if(quadConstraintValue.error > constraintValue->error)
                 constraintValue = quadConstraintValue;
         }
     }
     else if(properties.numberOfQuadraticConstraints > 0)
     {
         constraintValue = getMaxNumericConstraintValue(point, quadraticConstraints);
-    }
-    else
-    {
-        throw ConstraintNotFoundException("There are no quadratic or nonlinear constraints.");
     }
 
     return (constraintValue);

--- a/src/Model/Problem.h
+++ b/src/Model/Problem.h
@@ -175,7 +175,7 @@ public:
     std::shared_ptr<std::vector<std::pair<VariablePtr, VariablePtr>>> getLagrangianHessianSparsityPattern();
 
     std::optional<NumericConstraintValue> getMostDeviatingNumericConstraint(const VectorDouble& point);
-
+    std::optional<NumericConstraintValue> getMostDeviatingNonlinearOrQuadraticConstraint(const VectorDouble& point);
     std::optional<NumericConstraintValue> getMostDeviatingNonlinearConstraint(const VectorDouble& point);
 
     template <typename T>

--- a/src/NLPSolver/NLPSolverGAMS.cpp
+++ b/src/NLPSolver/NLPSolverGAMS.cpp
@@ -40,40 +40,41 @@ NLPSolverGAMS::NLPSolverGAMS(EnvironmentPtr envPtr, gmoHandle_t modelingObject, 
         assert(auditLicensing != nullptr);
         if(!palLicenseCheckSubSys(auditLicensing, (char*)"CO"))
         {
-            env->output->outputDebug("CONOPT licensed. Using CONOPT as GAMS NLP solver.");
+            env->output->outputDebug("        CONOPT licensed. Using CONOPT as GAMS NLP solver.");
             nlpsolver = "conopt";
             selectedNLPSolver = "CONOPT (automatically selected)";
         }
         else if(!palLicenseCheckSubSys(auditLicensing, (char*)"KN"))
         {
-            env->output->outputDebug("CONOPT not licensed. KNITRO licensed. Using KNITRO as GAMS NLP solver.");
+            env->output->outputDebug("        CONOPT not licensed. KNITRO licensed. Using KNITRO as GAMS NLP solver.");
             nlpsolver = "knitro";
             selectedNLPSolver = "KNITRO (automatically selected)";
         }
         else if(!palLicenseCheckSubSys(auditLicensing, (char*)"SN"))
         {
-            env->output->outputDebug("CONOPT and KNITRO not licensed. SNOPT licensed. Using SNOPT as GAMS NLP solver.");
+            env->output->outputDebug(
+                "        CONOPT and KNITRO not licensed. SNOPT licensed. Using SNOPT as GAMS NLP solver.");
             nlpsolver = "snopt";
             selectedNLPSolver = "SNOPT (automatically selected)";
         }
         else if(!palLicenseCheckSubSys(auditLicensing, (char*)"M5"))
         {
             env->output->outputDebug(
-                "CONOPT, KNITRO, and SNOPT not licensed. MINOS licensed. Using MINOS as GAMS NLP solver.");
+                "        CONOPT, KNITRO, and SNOPT not licensed. MINOS licensed. Using MINOS as GAMS NLP solver.");
             nlpsolver = "minos";
             selectedNLPSolver = "MINOS (automatically selected)";
         }
         else if(!palLicenseCheckSubSys(auditLicensing, (char*)"IP"))
         {
-            env->output->outputDebug(
-                "CONOPT, KNITRO, SNOPT, and MINOS not licensed. IPOPTH licensed. Using IPOPTH as GAMS NLP solver.");
+            env->output->outputDebug("        CONOPT, KNITRO, SNOPT, and MINOS not licensed. IPOPTH licensed. Using "
+                                     "IPOPTH as GAMS NLP solver.");
             nlpsolver = "ipopth";
             selectedNLPSolver = "IPOPTH (automatically selected)";
         }
         else
         {
             env->output->outputDebug(
-                "CONOPT, KNITRO, SNOPT, MINOS, and IPOPTH not licensed. Using IPOPT as GAMS NLP solver.");
+                "        CONOPT, KNITRO, SNOPT, MINOS, and IPOPTH not licensed. Using IPOPT as GAMS NLP solver.");
             nlpsolver = "ipopt";
             selectedNLPSolver = "IPOPT (automatically selected)";
         }

--- a/src/Report.cpp
+++ b/src/Report.cpp
@@ -310,7 +310,7 @@ void Report::outputSolverHeader()
 
     env->output->outputInfo("");
 
-    env->output->outputInfo(" Andreas Lundell and Jan Kronqvist, Åbo Akademi University, Finland.");
+    env->output->outputInfo(fmt::format(" Andreas Lundell and Jan Kronqvist, Åbo Akademi University, Finland."));
     env->output->outputInfo(" See documentation for full list of contributors and utilized software libraries.");
 
     env->output->outputInfo("");

--- a/src/Report.cpp
+++ b/src/Report.cpp
@@ -165,12 +165,8 @@ void Report::outputIterationDetail(int iterationNumber, std::string iterationDes
         if(env->results->getCurrentIteration()->numberOfExploredNodes > 0
             || env->results->getCurrentIteration()->numberOfOpenNodes > 0)
         {
-            env->output->outputDebug(fmt::format("        Explored nodes: + {} = {}.",
-                env->results->getCurrentIteration()->numberOfExploredNodes,
-                env->solutionStatistics.numberOfExploredNodes));
-
-            env->output->outputDebug(
-                fmt::format("        Open nodes:     {}", env->results->getCurrentIteration()->numberOfOpenNodes));
+            env->output->outputDebug(fmt::format("        Explored nodes: {}. Open nodes: {}.",
+                env->solutionStatistics.numberOfExploredNodes, env->results->getCurrentIteration()->numberOfOpenNodes));
         }
     }
     catch(...)

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -775,6 +775,9 @@ void Solver::initializeSettings()
     env->settings->createSetting("MIP.InfeasibilityRepair.TimeLimit", "Dual", 10.0,
         "Time limit when reparing infeasible problem", 0, SHOT_DBL_MAX);
 
+    env->settings->createSetting("MIP.OptimalityTolerance", "Dual", 1e-6,
+        "The reduced-cost tolerance for optimality in the MIP solver", 1e-9, 1e-2);
+
     env->settings->createSetting("MIP.NodeLimit", "Dual", SHOT_DBL_MAX,
         "Node limit to use for MIP solver in single-tree strategy", 0.0, SHOT_DBL_MAX);
 

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -1434,8 +1434,7 @@ void Solver::initializeSettings()
         "Rootsearch.MaxIterations", "Subsolver", 100, "Maximal root search iterations", 0, SHOT_INT_MAX);
 
     VectorString enumRootsearchMethod;
-    enumRootsearchMethod.push_back("BoostTOMS748");
-    enumRootsearchMethod.push_back("BoostBisection");
+    enumRootsearchMethod.push_back("TOMS748");
     enumRootsearchMethod.push_back("Bisection");
     env->settings->createSetting("Rootsearch.Method", "Subsolver", static_cast<int>(ES_RootsearchMethod::BoostTOMS748),
         "Root search method to use", enumRootsearchMethod, 0);

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -1144,8 +1144,6 @@ void Solver::initializeSettings()
     env->settings->createSetting("FixedInteger.UsePresolveBounds", "Primal", false,
         "Use variable bounds from MIP in NLP problems. Warning! Does not seem to work", true);
 
-    env->settings->createSetting("FixedInteger.ProblemSource", "Primal", true, "Use the fixed integer primal strategy");
-
     env->settings->createSetting("FixedInteger.Warmstart", "Primal", true, "Warm start the NLP solver");
 
     // Primal settings: rootsearch

--- a/src/Tasks/TaskReformulateProblem.cpp
+++ b/src/Tasks/TaskReformulateProblem.cpp
@@ -152,6 +152,9 @@ TaskReformulateProblem::TaskReformulateProblem(EnvironmentPtr envPtr) : TaskBase
     // Reformulating objective function
     reformulateObjectiveFunction();
 
+    // Creating expressions for sums of squares partitioning
+    createSquareReformulations();
+
     // Creating expressions for the bilinear reformulations
     createBilinearReformulations();
 
@@ -309,7 +312,7 @@ void TaskReformulateProblem::reformulateObjectiveFunction()
         if(partitionQuadraticTermsInObjective)
         {
             auto [tmpLinearTerms, tmpQuadraticTerms]
-                = reformulateAndPartitionQuadraticSum(sourceObjective->quadraticTerms, isSignReversed, true);
+                = reformulateAndPartitionQuadraticSum(sourceObjective->quadraticTerms, isSignReversed, true, true);
 
             destinationLinearTerms.add(tmpLinearTerms);
             destinationQuadraticTerms.add(tmpQuadraticTerms);
@@ -706,8 +709,8 @@ NumericConstraints TaskReformulateProblem::reformulateConstraint(NumericConstrai
             partitionTerms = false;
         }
 
-        auto [tmpLinearTerms, tmpQuadraticTerms]
-            = reformulateAndPartitionQuadraticSum(sourceConstraint->quadraticTerms, isSignReversed, partitionTerms);
+        auto [tmpLinearTerms, tmpQuadraticTerms] = reformulateAndPartitionQuadraticSum(
+            sourceConstraint->quadraticTerms, isSignReversed, partitionTerms, true);
 
         destinationLinearTerms.add(tmpLinearTerms);
         destinationQuadraticTerms.add(tmpQuadraticTerms);
@@ -823,7 +826,13 @@ NumericConstraints TaskReformulateProblem::reformulateConstraint(NumericConstrai
             destinationLinearTerms.add(tmpLinearTerms);
 
         if(tmpQuadraticTerms.size() > 0)
-            destinationQuadraticTerms.add(tmpQuadraticTerms);
+        {
+            auto [tmpLinearTerms2, tmpQuadraticTerms2]
+                = reformulateAndPartitionQuadraticSum(tmpQuadraticTerms, false, true, true);
+
+            destinationLinearTerms.add(tmpLinearTerms2);
+            destinationQuadraticTerms.add(tmpQuadraticTerms2);
+        }
 
         if(tmpMonomialTerms.size() > 0)
             destinationMonomialTerms.add(tmpMonomialTerms);
@@ -1128,7 +1137,7 @@ LinearTerms TaskReformulateProblem::partitionNonlinearSum(
                 }
 
                 auto [tmpLinearTerms, tmpQuadraticTerms]
-                    = reformulateAndPartitionQuadraticSum(quadTerms, reversedSigns, partitionTerms);
+                    = reformulateAndPartitionQuadraticSum(quadTerms, reversedSigns, partitionTerms, true);
 
                 if(tmpQuadraticTerms.size() == 0)
                 // Otherwise we cannot proceed and will continue as if nonbilinear term
@@ -1392,7 +1401,8 @@ LinearTerms TaskReformulateProblem::partitionSignomialTerms(const SignomialTerms
 }
 
 std::tuple<LinearTerms, QuadraticTerms> TaskReformulateProblem::reformulateAndPartitionQuadraticSum(
-    const QuadraticTerms& quadraticTerms, bool reversedSigns, bool partitionNonBinaryTerms)
+    const QuadraticTerms& quadraticTerms, bool reversedSigns, bool partitionNonBinaryTerms,
+    bool partitionIfAllTermsConvex)
 {
     LinearTerms resultLinearTerms;
     QuadraticTerms resultQuadraticTerms;
@@ -1400,12 +1410,22 @@ std::tuple<LinearTerms, QuadraticTerms> TaskReformulateProblem::reformulateAndPa
     double signfactor = reversedSigns ? -1.0 : 1.0;
 
     bool allTermsAreBinary = true;
+    bool allTermsConvex = true;
 
     for(auto& T : quadraticTerms)
     {
         if(!T->isBinary)
         {
             allTermsAreBinary = false;
+            break;
+        }
+    }
+
+    for(auto& T : quadraticTerms)
+    {
+        if(T->getConvexity() != E_Convexity::Convex)
+        {
+            allTermsConvex = false;
             break;
         }
     }
@@ -1429,6 +1449,11 @@ std::tuple<LinearTerms, QuadraticTerms> TaskReformulateProblem::reformulateAndPa
                 resultQuadraticTerms.add(
                     std::make_shared<QuadraticTerm>(T->coefficient, firstVariable, secondVariable));
             }
+        }
+        else if(partitionIfAllTermsConvex && allTermsConvex)
+        {
+            auto [auxVariable, newVariable] = getSquareAuxiliaryVariable(T->firstVariable);
+            resultLinearTerms.add(std::make_shared<LinearTerm>(signfactor * T->coefficient, auxVariable));
         }
         else if(T->isSquare && allTermsAreBinary) // Square term b^2 -> b
         {
@@ -2054,6 +2079,52 @@ NonlinearExpressionPtr TaskReformulateProblem::reformulateNonlinearExpression(st
     return (simplify(source));
 }
 
+std::pair<AuxiliaryVariablePtr, bool> TaskReformulateProblem::getSquareAuxiliaryVariable(VariablePtr variable)
+{
+    auto auxVariableIterator = squareAuxVariables.find(variable);
+
+    if(auxVariableIterator != squareAuxVariables.end())
+        return (std::make_pair(auxVariableIterator->second, false));
+
+    // Create a new variable
+
+    // Get the max bounds
+    auto valueList = { variable->lowerBound * variable->lowerBound, variable->upperBound * variable->upperBound };
+
+    double lowerBound = std::min(valueList);
+    double upperBound = std::max(valueList);
+
+    E_VariableType variableType;
+    E_AuxiliaryVariableType auxVariableType;
+
+    if(variable->properties.type == E_VariableType::Binary)
+    {
+        variableType = E_VariableType::Binary;
+    }
+    else if(variable->properties.type == E_VariableType::Integer)
+    {
+        variableType = E_VariableType::Integer;
+    }
+    else
+    {
+        variableType = E_VariableType::Real;
+    }
+
+    auxVariableType = E_AuxiliaryVariableType::SquareTermsPartitioning;
+
+    auto auxVariable = std::make_shared<AuxiliaryVariable>(
+        "s_sq_" + variable->name, auxVariableCounter, variableType, lowerBound, upperBound);
+    auxVariableCounter++;
+    auxVariable->properties.auxiliaryType = auxVariableType;
+    env->results->increaseAuxiliaryVariableCounter(auxVariableType);
+
+    reformulatedProblem->add((auxVariable));
+    auxVariable->quadraticTerms.add(std::make_shared<QuadraticTerm>(1.0, variable, variable));
+    squareAuxVariables.emplace(variable, auxVariable);
+
+    return (std::make_pair(auxVariable, true));
+}
+
 std::pair<AuxiliaryVariablePtr, bool> TaskReformulateProblem::getBilinearAuxiliaryVariable(
     VariablePtr firstVariable, VariablePtr secondVariable)
 {
@@ -2152,6 +2223,15 @@ std::pair<AuxiliaryVariablePtr, bool> TaskReformulateProblem::getAbsoluteValueAu
     absoluteExpressionsAuxVariables.emplace(key, auxVariable);
 
     return (std::make_pair(auxVariable, true));
+}
+
+void TaskReformulateProblem::createSquareReformulations()
+{
+    for(const auto& [VAR, AUXVAR] : squareAuxVariables)
+    {
+        reformulateSquareTerm(VAR, AUXVAR);
+        AUXVAR->properties.auxiliaryType = E_AuxiliaryVariableType::SquareTermsPartitioning;
+    }
 }
 
 void TaskReformulateProblem::createBilinearReformulations()
@@ -2381,6 +2461,32 @@ void TaskReformulateProblem::reformulateIntegerBilinearTerm(
     }
 }
 
+void TaskReformulateProblem::reformulateSquareTerm(VariablePtr variable, AuxiliaryVariablePtr auxVariable)
+{
+    if(useConvexQuadraticConstraints)
+    {
+        auto auxConstraint = std::make_shared<QuadraticConstraint>(
+            auxConstraintCounter, "s_sq_" + std::to_string(auxConstraintCounter), SHOT_DBL_MIN, 0.0);
+        auxConstraintCounter++;
+
+        auxConstraint->add(std::make_shared<LinearTerm>(-1.0, auxVariable));
+        auxConstraint->add(std::make_shared<QuadraticTerm>(1.0, variable, variable));
+
+        reformulatedProblem->add(std::move(auxConstraint));
+    }
+    else
+    {
+        auto auxConstraint = std::make_shared<NonlinearConstraint>(
+            auxConstraintCounter, "s_sq_" + std::to_string(auxConstraintCounter), SHOT_DBL_MIN, 0.0);
+        auxConstraintCounter++;
+
+        auxConstraint->add(std::make_shared<LinearTerm>(-1.0, auxVariable));
+        auxConstraint->add(std::make_shared<QuadraticTerm>(1.0, variable, variable));
+
+        reformulatedProblem->add(std::move(auxConstraint));
+    }
+}
+
 void TaskReformulateProblem::reformulateRealBilinearTerm(
     VariablePtr firstVariable, VariablePtr secondVariable, AuxiliaryVariablePtr auxVariable)
 {
@@ -2400,7 +2506,7 @@ void TaskReformulateProblem::reformulateRealBilinearTerm(
     else
     {
         auto auxConstraint = std::make_shared<NonlinearConstraint>(
-            auxConstraintCounter, "s_blcc_" + std::to_string(auxConstraintCounter), SHOT_DBL_MIN, 0.0);
+            auxConstraintCounter, "s_blcc_" + std::to_string(auxConstraintCounter), 0.0, 0.0);
         auxConstraintCounter++;
 
         auxConstraint->add(std::make_shared<LinearTerm>(-1.0, auxVariable));

--- a/src/Tasks/TaskReformulateProblem.cpp
+++ b/src/Tasks/TaskReformulateProblem.cpp
@@ -2011,11 +2011,11 @@ NonlinearExpressionPtr TaskReformulateProblem::reformulateNonlinearExpression(st
 NonlinearExpressionPtr TaskReformulateProblem::reformulateNonlinearExpression(std::shared_ptr<ExpressionSquare> source)
 {
     // Extract all quadratic terms from inside of the nonlinear expression
-    auto convxity = source->getConvexity();
+    auto convexity = source->getConvexity();
 
     if((extractQuadraticTermsFromNonconvexExpressions
-           && !(convxity > E_Convexity::Convex || convxity == E_Convexity::Unknown))
-        || extractQuadraticTermsFromConvexExpressions)
+           && (convexity > E_Convexity::Convex || convexity == E_Convexity::Unknown))
+        || (extractQuadraticTermsFromConvexExpressions && convexity == E_Convexity::Convex))
     {
         auto [tmpLinearTerms, tmpQuadraticTerms, tmpMonomialTerms, tmpSignomialTerms, tmpNonlinearExpression,
             tmpConstant]

--- a/src/Tasks/TaskReformulateProblem.h
+++ b/src/Tasks/TaskReformulateProblem.h
@@ -89,8 +89,8 @@ private:
 
     LinearTerms partitionNonlinearBinaryProduct(const std::shared_ptr<ExpressionSum> source, bool reversedSigns);
 
-    std::tuple<LinearTerms, QuadraticTerms> reformulateAndPartitionQuadraticSum(
-        const QuadraticTerms& quadraticTerms, bool reversedSigns, bool partitionNonBinaryTerms);
+    std::tuple<LinearTerms, QuadraticTerms> reformulateAndPartitionQuadraticSum(const QuadraticTerms& quadraticTerms,
+        bool reversedSigns, bool partitionNonBinaryTerms, bool partitionIfAllTermsConvex);
     std::tuple<LinearTerms, MonomialTerms> reformulateMonomialSum(
         const MonomialTerms& monomialTerms, bool reversedSigns);
 
@@ -99,12 +99,17 @@ private:
     NonlinearExpressionPtr reformulateNonlinearExpression(std::shared_ptr<ExpressionSquare> source);
     NonlinearExpressionPtr reformulateNonlinearExpression(std::shared_ptr<ExpressionProduct> source);
 
+    std::pair<AuxiliaryVariablePtr, bool> getSquareAuxiliaryVariable(VariablePtr firstVariable);
+
     std::pair<AuxiliaryVariablePtr, bool> getBilinearAuxiliaryVariable(
         VariablePtr firstVariable, VariablePtr secondVariable);
 
     std::pair<AuxiliaryVariablePtr, bool> getAbsoluteValueAuxiliaryVariable(std::shared_ptr<ExpressionAbs> source);
 
+    void createSquareReformulations();
     void createBilinearReformulations();
+
+    void reformulateSquareTerm(VariablePtr variable, AuxiliaryVariablePtr auxVariable);
 
     void reformulateBinaryBilinearTerm(
         VariablePtr firstVariable, VariablePtr secondVariable, AuxiliaryVariablePtr auxVariable);
@@ -122,6 +127,8 @@ private:
     int auxConstraintCounter = 0;
 
     std::map<VariablePtr, Variables> integerAuxiliaryBinaryVariables;
+
+    std::map<VariablePtr, AuxiliaryVariablePtr> squareAuxVariables;
 
     std::map<std::tuple<VariablePtr, VariablePtr>, AuxiliaryVariablePtr> bilinearAuxVariables;
 

--- a/src/Tasks/TaskSelectPrimalCandidatesFromNLP.cpp
+++ b/src/Tasks/TaskSelectPrimalCandidatesFromNLP.cpp
@@ -400,18 +400,7 @@ bool TaskSelectPrimalCandidatesFromNLP::solveFixedNLP()
             // Add integer cut.
             if(env->settings->getSetting<bool>("HyperplaneCuts.UseIntegerCuts", "Dual")
                 && sourceProblem->properties.numberOfDiscreteVariables > 0)
-            {
-                env->output->outputDebug("         Adding integer cut from fixed NLP solution.");
-
-                IntegerCut integerCut;
-                integerCut.source = E_IntegerCutSource::NLPFixedInteger;
-                integerCut.variableValues.reserve(discreteVariableIndexes.size());
-
-                for(auto& I : discreteVariableIndexes)
-                    integerCut.variableValues.push_back(std::abs(round(CAND.point.at(I))));
-
-                env->dualSolver->addIntegerCut(integerCut);
-            }
+                createIntegerCut(CAND.point);
 
             if(env->settings->getSetting<bool>("FixedInteger.CreateInfeasibilityCut", "Primal"))
                 createInfeasibilityCut(variableSolution);
@@ -468,18 +457,7 @@ bool TaskSelectPrimalCandidatesFromNLP::solveFixedNLP()
             // Add integer cut.
             if(env->settings->getSetting<bool>("HyperplaneCuts.UseIntegerCuts", "Dual")
                 && sourceProblem->properties.numberOfDiscreteVariables > 0)
-            {
-                env->output->outputDebug("         Adding integer cut from fixed NLP solution.");
-
-                IntegerCut integerCut;
-                integerCut.source = E_IntegerCutSource::NLPFixedInteger;
-                integerCut.variableValues.reserve(discreteVariableIndexes.size());
-
-                for(auto& I : discreteVariableIndexes)
-                    integerCut.variableValues.push_back(std::abs(round(CAND.point.at(I))));
-
-                env->dualSolver->addIntegerCut(integerCut);
-            }
+                createIntegerCut(CAND.point);
         }
         else
         {
@@ -492,18 +470,7 @@ bool TaskSelectPrimalCandidatesFromNLP::solveFixedNLP()
             // Add integer cut.
             if(env->settings->getSetting<bool>("HyperplaneCuts.UseIntegerCuts", "Dual")
                 && sourceProblem->properties.numberOfDiscreteVariables > 0)
-            {
-                env->output->outputDebug("         Adding integer cut from fixed NLP solution.");
-
-                IntegerCut integerCut;
-                integerCut.source = E_IntegerCutSource::NLPFixedInteger;
-                integerCut.variableValues.reserve(discreteVariableIndexes.size());
-
-                for(auto& I : discreteVariableIndexes)
-                    integerCut.variableValues.push_back(std::abs(round(CAND.point.at(I))));
-
-                env->dualSolver->addIntegerCut(integerCut);
-            }
+                createIntegerCut(CAND.point);
         }
 
         env->solutionStatistics.numberOfIterationsWithoutNLPCallMIP = 0;
@@ -516,7 +483,7 @@ bool TaskSelectPrimalCandidatesFromNLP::solveFixedNLP()
     return (true);
 }
 
-void TaskSelectPrimalCandidatesFromNLP::createInfeasibilityCut(VectorDouble variableSolution)
+void TaskSelectPrimalCandidatesFromNLP::createInfeasibilityCut(const VectorDouble variableSolution)
 {
     env->output->outputDebug("         Adding infeasibility cut from fixed NLP solution.");
 
@@ -555,6 +522,20 @@ void TaskSelectPrimalCandidatesFromNLP::createInfeasibilityCut(VectorDouble vari
     {
         std::dynamic_pointer_cast<TaskSelectHyperplanePointsECP>(taskSelectHPPts)->run(solutionPoints);
     }
+}
+
+void TaskSelectPrimalCandidatesFromNLP::createIntegerCut(const VectorDouble variableSolution)
+{
+    env->output->outputDebug("         Adding integer cut from fixed NLP solution.");
+
+    IntegerCut integerCut;
+    integerCut.source = E_IntegerCutSource::NLPFixedInteger;
+    integerCut.variableValues.reserve(discreteVariableIndexes.size());
+
+    for(auto& I : discreteVariableIndexes)
+        integerCut.variableValues.push_back(std::abs(round(variableSolution.at(I))));
+
+    env->dualSolver->addIntegerCut(integerCut);
 }
 
 } // namespace SHOT

--- a/src/Tasks/TaskSelectPrimalCandidatesFromNLP.cpp
+++ b/src/Tasks/TaskSelectPrimalCandidatesFromNLP.cpp
@@ -93,19 +93,6 @@ TaskSelectPrimalCandidatesFromNLP::TaskSelectPrimalCandidatesFromNLP(Environment
 
     env->results->usedPrimalNLPSolverDescription = NLPSolver->getSolverDescription();
 
-    if(env->settings->getSetting<bool>("FixedInteger.CreateInfeasibilityCut", "Primal"))
-    {
-        if(static_cast<ES_HyperplaneCutStrategy>(env->settings->getSetting<int>("CutStrategy", "Dual"))
-            == ES_HyperplaneCutStrategy::ESH)
-        {
-            taskSelectHPPts = std::make_shared<TaskSelectHyperplanePointsESH>(env);
-        }
-        else
-        {
-            taskSelectHPPts = std::make_shared<TaskSelectHyperplanePointsECP>(env);
-        }
-    }
-
     this->originalIterFrequency = env->settings->getSetting<int>("FixedInteger.Frequency.Iteration", "Primal");
     this->originalTimeFrequency = env->settings->getSetting<double>("FixedInteger.Frequency.Time", "Primal");
 
@@ -512,6 +499,15 @@ void TaskSelectPrimalCandidatesFromNLP::createInfeasibilityCut(const VectorDoubl
 
     std::vector<SolutionPoint> solutionPoints(1);
     solutionPoints.at(0) = tmpSolPt;
+
+    if(!taskSelectHPPts)
+    {
+        if(static_cast<ES_HyperplaneCutStrategy>(env->settings->getSetting<int>("CutStrategy", "Dual"))
+            == ES_HyperplaneCutStrategy::ESH)
+            taskSelectHPPts = std::make_shared<TaskSelectHyperplanePointsESH>(env);
+        else
+            taskSelectHPPts = std::make_shared<TaskSelectHyperplanePointsECP>(env);
+    }
 
     if(static_cast<ES_HyperplaneCutStrategy>(env->settings->getSetting<int>("CutStrategy", "Dual"))
         == ES_HyperplaneCutStrategy::ESH)

--- a/src/Tasks/TaskSelectPrimalCandidatesFromNLP.h
+++ b/src/Tasks/TaskSelectPrimalCandidatesFromNLP.h
@@ -32,7 +32,8 @@ public:
 private:
     virtual bool solveFixedNLP();
 
-    void createInfeasibilityCut(VectorDouble point);
+    void createInfeasibilityCut(const VectorDouble point);
+    void createIntegerCut(const VectorDouble point);
 
     std::shared_ptr<INLPSolver> NLPSolver;
 

--- a/src/Tasks/TaskSelectPrimalCandidatesFromNLP.h
+++ b/src/Tasks/TaskSelectPrimalCandidatesFromNLP.h
@@ -32,6 +32,8 @@ public:
 private:
     virtual bool solveFixedNLP();
 
+    void createInfeasibilityCut(VectorDouble point);
+
     std::shared_ptr<INLPSolver> NLPSolver;
 
     VectorInteger discreteVariableIndexes;

--- a/src/Tasks/TaskSelectPrimalCandidatesFromNLP.h
+++ b/src/Tasks/TaskSelectPrimalCandidatesFromNLP.h
@@ -33,7 +33,7 @@ private:
     virtual bool solveFixedNLP();
 
     void createInfeasibilityCut(const VectorDouble point);
-    void createIntegerCut(const VectorDouble point);
+    void createIntegerCut(VectorDouble point);
 
     std::shared_ptr<INLPSolver> NLPSolver;
 


### PR DESCRIPTION
- Also do partitioning on sum of convex functions (including quadratic terms).
- Allow selecting similar primal solution with higher accuracy.
- Enhance debug output of fixed NLP strategy.
- Refactor task for fixed NLP strategy.
- No longer add integer cuts if NLP solver gives solution outside variable bounds. 
- Disable check for already added constraints if single-tree strategy is used (Gurobi and Cplex cannot guarantee that cuts are added in all threads).
- Add optimality tolerance setting for MIP solvers.
- Remove some unused options.
- Various other small fixes.