### PR TITLE
fix handling of GAMS iterlim and setting of GAMS mipbest/objest

### DIFF
--- a/src/ModelingSystem/ModelingSystemGAMS.cpp
+++ b/src/ModelingSystem/ModelingSystemGAMS.cpp
@@ -608,8 +608,7 @@ void ModelingSystemGAMS::finalizeSolution()
     gmoCompleteSolution(modelingObject);
 
     // set some more statistics, etc
-    gmoSetHeadnTail(modelingObject, gmoTmipbest,
-        r->currentDualBound); // TODO how do we know that a dual bound has actually been computed
+    gmoSetHeadnTail(modelingObject, gmoTmipbest, r->getGlobalDualBound());
     gmoSetHeadnTail(modelingObject, gmoHiterused, r->getCurrentIteration()->iterationNumber);
     // TODO this seems to be 0: gmoSetHeadnTail(modelingObject, gmoHiterused,
     // env->solutionStatistics.numberOfIterations);

--- a/src/ModelingSystem/ModelingSystemGAMS.cpp
+++ b/src/ModelingSystem/ModelingSystemGAMS.cpp
@@ -32,6 +32,7 @@
 
 #include <cstdio> // for tmpnam()
 #include <cstdlib> // for mkdtemp()
+#include <climits>
 #include <fstream>
 
 #ifdef HAS_STD_FILESYSTEM
@@ -106,8 +107,8 @@ void ModelingSystemGAMS::updateSettings(SettingsPtr settings)
         env->output->outputDebug(
             fmt::format("Time limit set to {} by GAMS", env->settings->getSetting<double>("TimeLimit", "Termination")));
 
-        // Sets iteration limit
-        if(gevGetIntOpt(modelingEnvironment, gevIterLim) != ITERLIM_INFINITY)
+        // Sets iteration limit, if different than SHOT default
+        if(gevGetIntOpt(modelingEnvironment, gevIterLim) < INT_MAX)
         {
             env->settings->updateSetting(
                 "IterationLimit", "Termination", gevGetIntOpt(modelingEnvironment, gevIterLim));


### PR DESCRIPTION
Fix for passing on iteration limit to SHOT. The name ITERLIM_INFINITY is confusing and is actually used to represent the default iterlim. Even if the iterlim is left at the GAMS default, it should be passed on to SHOT. Only if set to the maximal value for an int, it doesn't pass it on (probably that is the SHOT default anyway).

Fix for passing dual bound back to GAMS. The `currentDualBound` was -infinity for instance https://www.minlplib.org/p_ball_10b_5p_2d_h.html, where SHOT stopped before proving global optimality (convexity is not detected here). But SHOT reported a (correct) dual bound of 0 in the log. Using getGlobalDualBound() seems to make sure that the 0 is passed back to GAMS as well.

Is it correct to base this on stable/1.0?