### PR TITLE
Improve quadratic partitioning

### DIFF
--- a/src/Model/Terms.h
+++ b/src/Model/Terms.h
@@ -294,7 +294,8 @@ public:
 
     bool isBilinear = false;
     bool isSquare = false;
-    bool isBinary = false;
+    bool isBinary = false; // Binary times binary
+    bool isInteger = false; // Integer times integer (non binary variables)
 
     QuadraticTerm() = default;
 
@@ -317,6 +318,11 @@ public:
             && secondVariable->properties.type == E_VariableType::Binary)
         {
             isBinary = true;
+        }
+        else if(firstVariable->properties.type == E_VariableType::Integer
+            && secondVariable->properties.type == E_VariableType::Integer)
+        {
+            isInteger = true;
         }
     };
 

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -983,7 +983,7 @@ void Solver::initializeSettings()
     // Reformulations for constraints
     VectorString enumNonlinearTermPartitioning;
     enumNonlinearTermPartitioning.push_back("Always");
-    enumNonlinearTermPartitioning.push_back("If convex");
+    enumNonlinearTermPartitioning.push_back("If result is convex");
     enumNonlinearTermPartitioning.push_back("Never");
     env->settings->createSetting("Reformulation.Constraint.PartitionNonlinearTerms", "Model",
         static_cast<int>(ES_PartitionNonlinearSums::IfConvex), "When to partition nonlinear sums in objective function",
@@ -1779,13 +1779,13 @@ void Solver::setConvexityBasedSettings()
             env->settings->updateSetting("Relaxation.Use", "Dual", false);
 
             env->settings->updateSetting(
-                "Reformulation.Constraint.PartitionNonlinearTerms", "Model", (int)ES_PartitionNonlinearSums::Always);
+                "Reformulation.Constraint.PartitionNonlinearTerms", "Model", (int)ES_PartitionNonlinearSums::IfConvex);
             env->settings->updateSetting(
-                "Reformulation.Constraint.PartitionQuadraticTerms", "Model", (int)ES_PartitionNonlinearSums::Always);
+                "Reformulation.Constraint.PartitionQuadraticTerms", "Model", (int)ES_PartitionNonlinearSums::IfConvex);
             env->settings->updateSetting("Reformulation.ObjectiveFunction.PartitionNonlinearTerms", "Model",
-                (int)ES_PartitionNonlinearSums::Always);
+                (int)ES_PartitionNonlinearSums::IfConvex);
             env->settings->updateSetting("Reformulation.ObjectiveFunction.PartitionQuadraticTerms", "Model",
-                (int)ES_PartitionNonlinearSums::Always);
+                (int)ES_PartitionNonlinearSums::IfConvex);
             // env->settings->updateSetting("Reformulation.Quadratics.Strategy", "Model", 0);
 
             env->settings->updateSetting("FixedInteger.CallStrategy", "Primal", 0);

--- a/src/Tasks/TaskExecuteSolutionLimitStrategy.cpp
+++ b/src/Tasks/TaskExecuteSolutionLimitStrategy.cpp
@@ -88,7 +88,7 @@ void TaskExecuteSolutionLimitStrategy::run()
             env->dualSolver->MIPSolver->setSolutionLimit(2100000000);
             temporaryOptLimitUsed = true;
             currIter->MIPSolutionLimitUpdated = true;
-            env->output->outputCritical(
+            env->output->outputDebug(
                 "        Forced optimal iteration since too long time since last dual bound update");
 
             env->timing->stopTimer("DualStrategy");

--- a/src/Tasks/TaskReformulateProblem.h
+++ b/src/Tasks/TaskReformulateProblem.h
@@ -89,8 +89,8 @@ private:
 
     LinearTerms partitionNonlinearBinaryProduct(const std::shared_ptr<ExpressionSum> source, bool reversedSigns);
 
-    std::tuple<LinearTerms, QuadraticTerms> reformulateAndPartitionQuadraticSum(const QuadraticTerms& quadraticTerms,
-        bool reversedSigns, bool partitionNonBinaryTerms, bool partitionIfAllTermsConvex);
+    std::tuple<LinearTerms, QuadraticTerms> reformulateAndPartitionQuadraticSum(
+        const QuadraticTerms& quadraticTerms, bool reversedSigns, ES_PartitionNonlinearSums partitionStrategy);
     std::tuple<LinearTerms, MonomialTerms> reformulateMonomialSum(
         const MonomialTerms& monomialTerms, bool reversedSigns);
 


### PR DESCRIPTION
Enable quadratic partitioning also for instances where the end result is a sum of convex terms (i.e. after reformulation), without requiring that all terms from the beginning are convex. 