### PR TITLE
in GAMS interface, write alternative solutions to GDX file, if requested

### DIFF
--- a/src/ModelingSystem/ModelingSystemGAMS.cpp
+++ b/src/ModelingSystem/ModelingSystemGAMS.cpp
@@ -622,7 +622,7 @@ void ModelingSystemGAMS::finalizeSolution()
         gmoUnloadSolutionLegacy(modelingObject);
 
     // write alternate solutions to GDX file, if requested
-    std::string solfile = env->settings->getSetting<std::string>("GAMS.SolutionsFile", "Subsolver");
+    std::string solfile = env->settings->getSetting<std::string>("GAMS.AlternateSolutionsFile", "Output");
 
     if(!solfile.empty() && r->primalSolutions.size() > 1)
     {

--- a/src/ModelingSystem/ModelingSystemGAMS.cpp
+++ b/src/ModelingSystem/ModelingSystemGAMS.cpp
@@ -85,7 +85,8 @@ void ModelingSystemGAMS::updateSettings(SettingsPtr settings)
     assert(modelingEnvironment != nullptr);
     assert(modelingObject != nullptr);
 
-    settings->createSetting("SolutionsFile", "Output", std::string(), "Name of GDX file to write alternative solutions to", false);
+    settings->createSetting(
+        "SolutionsFile", "Output", std::string(), "Name of GDX file to write alternative solutions to", false);
 
 #ifdef GAMS_BUILD
     assert(auditLicensing != nullptr);
@@ -625,45 +626,49 @@ void ModelingSystemGAMS::finalizeSolution()
 
     // write alternate solutions to GDX file, if requested
     std::string solfile = env->settings->getSetting<std::string>("SolutionsFile", "Output");
-    if( !solfile.empty() && r->primalSolutions.size() > 1 )
+    if(!solfile.empty() && r->primalSolutions.size() > 1)
     {
         int solnvarsym;
 
-        if( gmoCheckSolPoolUEL(modelingObject, "soln_shot_p", &solnvarsym) )
+        if(gmoCheckSolPoolUEL(modelingObject, "soln_shot_p", &solnvarsym))
         {
-            env->output->outputError("Solution pool scenario label 'soln_shot_p' contained in model dictionary. Cannot dump merged solutions pool.");
+            env->output->outputError("Solution pool scenario label 'soln_shot_p' contained in model dictionary. Cannot "
+                                     "dump merged solutions pool.");
         }
         else
         {
             void* handle;
             bool error = false;
 
-            handle = gmoPrepareSolPoolMerge(modelingObject, solfile.c_str(), r->primalSolutions.size()-1, "soln_shot_p");
-            if( handle != NULL )
+            handle
+                = gmoPrepareSolPoolMerge(modelingObject, solfile.c_str(), r->primalSolutions.size() - 1, "soln_shot_p");
+            if(handle != NULL)
             {
-                for( int k = 0; k < solnvarsym && !error; k++ )
+                for(int k = 0; k < solnvarsym && !error; k++)
                 {
                     gmoPrepareSolPoolNextSym(modelingObject, handle);
-                    for( int i = 1; i < r->primalSolutions.size(); ++i )
+                    for(int i = 1; i < r->primalSolutions.size(); ++i)
                     {
                         gmoSetVarL(modelingObject, &r->primalSolutions[i].point[0]);
-                        if( gmoUnloadSolPoolSolution(modelingObject, handle, i-1) )
+                        if(gmoUnloadSolPoolSolution(modelingObject, handle, i - 1))
                         {
-                            env->output->outputError("Problems unloading solution point " + std::to_string(i) + " symbol " + std::to_string(k));
+                            env->output->outputError("Problems unloading solution point " + std::to_string(i)
+                                + " symbol " + std::to_string(k));
                             error = true;
                             break;
                         }
                     }
                 }
-                if( gmoFinalizeSolPoolMerge(modelingObject, handle) )
+                if(gmoFinalizeSolPoolMerge(modelingObject, handle))
                 {
                     env->output->outputError("Problems finalizing merged solution pool");
                     error = true;
                 }
-                if( !error )
+                if(!error)
                 {
                     env->output->outputInfo("");
-                    env->output->outputInfo(" Written " + std::to_string(r->primalSolutions.size()-1) + " alternate solutions to " + solfile);
+                    env->output->outputInfo(" Written " + std::to_string(r->primalSolutions.size() - 1)
+                        + " alternate solutions to " + solfile);
                 }
             }
             else
@@ -672,7 +677,7 @@ void ModelingSystemGAMS::finalizeSolution()
             }
         }
     }
-    else if( !solfile.empty() && r->primalSolutions.size() == 1 )
+    else if(!solfile.empty() && r->primalSolutions.size() == 1)
     {
         env->output->outputInfo("");
         env->output->outputInfo(" Only one solution found, skip dumping alternate solutions.");

--- a/src/ModelingSystem/ModelingSystemGAMS.cpp
+++ b/src/ModelingSystem/ModelingSystemGAMS.cpp
@@ -85,9 +85,6 @@ void ModelingSystemGAMS::updateSettings(SettingsPtr settings)
     assert(modelingEnvironment != nullptr);
     assert(modelingObject != nullptr);
 
-    settings->createSetting(
-        "SolutionsFile", "GAMS", std::string(), "Name of GDX file to write alternative solutions to", false);
-
 #ifdef GAMS_BUILD
     assert(auditLicensing != nullptr);
 
@@ -625,7 +622,7 @@ void ModelingSystemGAMS::finalizeSolution()
         gmoUnloadSolutionLegacy(modelingObject);
 
     // write alternate solutions to GDX file, if requested
-    std::string solfile = env->settings->getSetting<std::string>("SolutionsFile", "GAMS");
+    std::string solfile = env->settings->getSetting<std::string>("GAMS.SolutionsFile", "Subsolver");
 
     if(!solfile.empty() && r->primalSolutions.size() > 1)
     {

--- a/src/ModelingSystem/ModelingSystemGAMS.cpp
+++ b/src/ModelingSystem/ModelingSystemGAMS.cpp
@@ -107,8 +107,8 @@ void ModelingSystemGAMS::updateSettings(SettingsPtr settings)
     {
         // Sets time limit
         env->settings->updateSetting("TimeLimit", "Termination", gevGetDblOpt(modelingEnvironment, gevResLim));
-        env->output->outputDebug(
-            fmt::format("Time limit set to {} by GAMS", env->settings->getSetting<double>("TimeLimit", "Termination")));
+        env->output->outputDebug(fmt::format(
+            " Time limit set to {} by GAMS", env->settings->getSetting<double>("TimeLimit", "Termination")));
 
         // Sets iteration limit, if different than SHOT default
         if(gevGetIntOpt(modelingEnvironment, gevIterLim) < INT_MAX)
@@ -116,7 +116,7 @@ void ModelingSystemGAMS::updateSettings(SettingsPtr settings)
             env->settings->updateSetting(
                 "IterationLimit", "Termination", gevGetIntOpt(modelingEnvironment, gevIterLim));
             env->output->outputDebug(fmt::format(
-                "Iteration limit set to {} by GAMS", env->settings->getSetting<int>("IterationLimit", "Termination")));
+                " Iteration limit set to {} by GAMS", env->settings->getSetting<int>("IterationLimit", "Termination")));
         }
         else
         {
@@ -126,13 +126,13 @@ void ModelingSystemGAMS::updateSettings(SettingsPtr settings)
         // Sets absolute objective gap tolerance
         env->settings->updateSetting(
             "ObjectiveGap.Absolute", "Termination", gevGetDblOpt(modelingEnvironment, gevOptCA));
-        env->output->outputDebug(fmt::format("Absolute termination tolerance set to {} by GAMS",
+        env->output->outputDebug(fmt::format(" Absolute termination tolerance set to {} by GAMS",
             env->settings->getSetting<double>("ObjectiveGap.Absolute", "Termination")));
 
         // Sets relative objective gap tolerance
         env->settings->updateSetting(
             "ObjectiveGap.Relative", "Termination", gevGetDblOpt(modelingEnvironment, gevOptCR));
-        env->output->outputDebug(fmt::format("Relative termination tolerance set to {} by GAMS",
+        env->output->outputDebug(fmt::format(" Relative termination tolerance set to {} by GAMS",
             env->settings->getSetting<double>("ObjectiveGap.Relative", "Termination")));
 
         // Sets cutoff value for dual solver
@@ -153,7 +153,7 @@ void ModelingSystemGAMS::updateSettings(SettingsPtr settings)
         // Sets the number of threads
         env->settings->updateSetting("MIP.NumberOfThreads", "Dual", gevThreads(modelingEnvironment));
         env->output->outputDebug(fmt::format(
-            "MIP number of threads set to {} by GAMS", env->settings->getSetting<int>("MIP.NumberOfThreads", "Dual")));
+            " MIP number of threads set to {} by GAMS", env->settings->getSetting<int>("MIP.NumberOfThreads", "Dual")));
 
         // Uses NLP solver in GAMS by default, Ipopt can be used directly if value set by user in options file (read
         // below)
@@ -203,7 +203,7 @@ E_ProblemCreationStatus ModelingSystemGAMS::createProblem(
 {
     if(!fs::filesystem::exists(filename))
     {
-        env->output->outputError("File \"" + filename + "\" does not exist.");
+        env->output->outputError(" File \"" + filename + "\" does not exist.");
 
         return (E_ProblemCreationStatus::FileDoesNotExist);
     }
@@ -633,8 +633,9 @@ void ModelingSystemGAMS::finalizeSolution()
 
         if(gmoCheckSolPoolUEL(modelingObject, "soln_shot_p", &solnvarsym))
         {
-            env->output->outputError("Solution pool scenario label 'soln_shot_p' contained in model dictionary. Cannot "
-                                     "dump merged solutions pool.");
+            env->output->outputError(
+                " Solution pool scenario label 'soln_shot_p' contained in model dictionary. Cannot "
+                "dump merged solutions pool.");
         }
         else
         {
@@ -656,7 +657,7 @@ void ModelingSystemGAMS::finalizeSolution()
 
                         if(gmoUnloadSolPoolSolution(modelingObject, handle, i - 1))
                         {
-                            env->output->outputError("Problems unloading solution point " + std::to_string(i)
+                            env->output->outputError(" Problems unloading solution point " + std::to_string(i)
                                 + " symbol " + std::to_string(k));
                             error = true;
                             break;
@@ -665,7 +666,7 @@ void ModelingSystemGAMS::finalizeSolution()
                 }
                 if(gmoFinalizeSolPoolMerge(modelingObject, handle))
                 {
-                    env->output->outputError("Problems finalizing merged solution pool");
+                    env->output->outputError(" Problems finalizing merged solution pool");
                     error = true;
                 }
                 if(!error)
@@ -677,7 +678,7 @@ void ModelingSystemGAMS::finalizeSolution()
             }
             else
             {
-                env->output->outputError("Problems preparing merged solution pool\n");
+                env->output->outputError(" Problems preparing merged solution pool\n");
             }
         }
     }
@@ -805,7 +806,7 @@ bool ModelingSystemGAMS::copyVariables(ProblemPtr destination)
 
                 break;
             case gmovar_SI:
-                env->output->outputError("Unsupported variable type.");
+                env->output->outputError(" Unsupported variable type.");
 
                 delete[] variableLBs;
                 delete[] variableUBs;
@@ -813,7 +814,7 @@ bool ModelingSystemGAMS::copyVariables(ProblemPtr destination)
                 return (false);
                 break;
             case gmovar_S1:
-                env->output->outputError("Unsupported variable type.");
+                env->output->outputError(" Unsupported variable type.");
 
                 delete[] variableLBs;
                 delete[] variableUBs;
@@ -821,7 +822,7 @@ bool ModelingSystemGAMS::copyVariables(ProblemPtr destination)
                 return (false);
                 break;
             case gmovar_S2:
-                env->output->outputError("Unsupported variable type.");
+                env->output->outputError(" Unsupported variable type.");
 
                 delete[] variableLBs;
                 delete[] variableUBs;
@@ -829,7 +830,7 @@ bool ModelingSystemGAMS::copyVariables(ProblemPtr destination)
                 return (false);
                 break;
             default:
-                env->output->outputError("Unsupported variable type.");
+                env->output->outputError(" Unsupported variable type.");
 
                 delete[] variableLBs;
                 delete[] variableUBs;
@@ -847,7 +848,7 @@ bool ModelingSystemGAMS::copyVariables(ProblemPtr destination)
     }
     else
     {
-        env->output->outputError("Problem has no variables.");
+        env->output->outputError(" Problem has no variables.");
 
         return (false);
     }
@@ -865,7 +866,7 @@ bool ModelingSystemGAMS::copyObjectiveFunction(ProblemPtr destination)
     if(gmoModelType(modelingObject) == gmoProc_cns)
     {
         // no objective in constraint satisfaction models
-        env->output->outputError("Problem has no objective function.");
+        env->output->outputError(" Problem has no objective function.");
         return (false);
     }
 
@@ -886,7 +887,7 @@ bool ModelingSystemGAMS::copyObjectiveFunction(ProblemPtr destination)
         break;
 
     default:
-        env->output->outputError("Objective function of unknown type.");
+        env->output->outputError(" Objective function of unknown type.");
         return (false);
         break;
     }
@@ -977,7 +978,7 @@ bool ModelingSystemGAMS::copyConstraints(ProblemPtr destination)
                 break;
 
             default:
-                env->output->outputError("Constraint index" + std::to_string(i) + "is of unknown type.");
+                env->output->outputError(" Constraint index" + std::to_string(i) + "is of unknown type.");
                 return (false);
             }
 
@@ -1007,14 +1008,14 @@ bool ModelingSystemGAMS::copyConstraints(ProblemPtr destination)
                 break;
             }
             default:
-                env->output->outputError("Constraint index" + std::to_string(i) + "is of unknown type.");
+                env->output->outputError(" Constraint index" + std::to_string(i) + "is of unknown type.");
                 return (false);
             }
         }
     }
     else
     {
-        env->output->outputDebug("GAMS modeling object does not have any constraints.");
+        env->output->outputDebug(" GAMS modeling object does not have any constraints.");
     }
 
     env->output->outputTrace(" Finished copying constraints between GAMS modeling and SHOT problem objects.");

--- a/src/ModelingSystem/ModelingSystemGAMS.cpp
+++ b/src/ModelingSystem/ModelingSystemGAMS.cpp
@@ -86,7 +86,7 @@ void ModelingSystemGAMS::updateSettings(SettingsPtr settings)
     assert(modelingObject != nullptr);
 
     settings->createSetting(
-        "SolutionsFile", "Output", std::string(), "Name of GDX file to write alternative solutions to", false);
+        "SolutionsFile", "GAMS", std::string(), "Name of GDX file to write alternative solutions to", false);
 
 #ifdef GAMS_BUILD
     assert(auditLicensing != nullptr);
@@ -625,7 +625,8 @@ void ModelingSystemGAMS::finalizeSolution()
         gmoUnloadSolutionLegacy(modelingObject);
 
     // write alternate solutions to GDX file, if requested
-    std::string solfile = env->settings->getSetting<std::string>("SolutionsFile", "Output");
+    std::string solfile = env->settings->getSetting<std::string>("SolutionsFile", "GAMS");
+
     if(!solfile.empty() && r->primalSolutions.size() > 1)
     {
         int solnvarsym;

--- a/src/ModelingSystem/ModelingSystemGAMS.cpp
+++ b/src/ModelingSystem/ModelingSystemGAMS.cpp
@@ -643,14 +643,17 @@ void ModelingSystemGAMS::finalizeSolution()
 
             handle
                 = gmoPrepareSolPoolMerge(modelingObject, solfile.c_str(), r->primalSolutions.size() - 1, "soln_shot_p");
+
             if(handle != NULL)
             {
                 for(int k = 0; k < solnvarsym && !error; k++)
                 {
                     gmoPrepareSolPoolNextSym(modelingObject, handle);
+
                     for(int i = 1; i < r->primalSolutions.size(); ++i)
                     {
                         gmoSetVarL(modelingObject, &r->primalSolutions[i].point[0]);
+
                         if(gmoUnloadSolPoolSolution(modelingObject, handle, i - 1))
                         {
                             env->output->outputError("Problems unloading solution point " + std::to_string(i)

--- a/src/ModelingSystem/ModelingSystemGAMS.cpp
+++ b/src/ModelingSystem/ModelingSystemGAMS.cpp
@@ -85,6 +85,8 @@ void ModelingSystemGAMS::updateSettings(SettingsPtr settings)
     assert(modelingEnvironment != nullptr);
     assert(modelingObject != nullptr);
 
+    settings->createSetting("SolutionsFile", "Output", std::string(), "Name of GDX file to write alternative solutions to", false);
+
 #ifdef GAMS_BUILD
     assert(auditLicensing != nullptr);
 
@@ -620,6 +622,61 @@ void ModelingSystemGAMS::finalizeSolution()
     // removed here)
     if(createdgmo)
         gmoUnloadSolutionLegacy(modelingObject);
+
+    // write alternate solutions to GDX file, if requested
+    std::string solfile = env->settings->getSetting<std::string>("SolutionsFile", "Output");
+    if( !solfile.empty() && r->primalSolutions.size() > 1 )
+    {
+        int solnvarsym;
+
+        if( gmoCheckSolPoolUEL(modelingObject, "soln_shot_p", &solnvarsym) )
+        {
+            env->output->outputError("Solution pool scenario label 'soln_shot_p' contained in model dictionary. Cannot dump merged solutions pool.");
+        }
+        else
+        {
+            void* handle;
+            bool error = false;
+
+            handle = gmoPrepareSolPoolMerge(modelingObject, solfile.c_str(), r->primalSolutions.size()-1, "soln_shot_p");
+            if( handle != NULL )
+            {
+                for( int k = 0; k < solnvarsym && !error; k++ )
+                {
+                    gmoPrepareSolPoolNextSym(modelingObject, handle);
+                    for( int i = 1; i < r->primalSolutions.size(); ++i )
+                    {
+                        gmoSetVarL(modelingObject, &r->primalSolutions[i].point[0]);
+                        if( gmoUnloadSolPoolSolution(modelingObject, handle, i-1) )
+                        {
+                            env->output->outputError("Problems unloading solution point " + std::to_string(i) + " symbol " + std::to_string(k));
+                            error = true;
+                            break;
+                        }
+                    }
+                }
+                if( gmoFinalizeSolPoolMerge(modelingObject, handle) )
+                {
+                    env->output->outputError("Problems finalizing merged solution pool");
+                    error = true;
+                }
+                if( !error )
+                {
+                    env->output->outputInfo("");
+                    env->output->outputInfo(" Written " + std::to_string(r->primalSolutions.size()-1) + " alternate solutions to " + solfile);
+                }
+            }
+            else
+            {
+                env->output->outputError("Problems preparing merged solution pool\n");
+            }
+        }
+    }
+    else if( !solfile.empty() && r->primalSolutions.size() == 1 )
+    {
+        env->output->outputInfo("");
+        env->output->outputInfo(" Only one solution found, skip dumping alternate solutions.");
+    }
 }
 
 void ModelingSystemGAMS::clearGAMSObjects()

--- a/src/SHOT.cpp
+++ b/src/SHOT.cpp
@@ -689,6 +689,7 @@ int main(int argc, char* argv[])
         return (0);
     }
 
+    solver.finalizeSolution();
     env->report->outputSolutionReport();
 
 #ifdef SIMPLE_OUTPUT_CHARS

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -1434,6 +1434,9 @@ void Solver::initializeSettings()
     env->settings->createSetting(
         "GAMS.NLP.Solver", "Subsolver", solver, "NLP solver to use in GAMS (auto: SHOT chooses)");
 
+    env->settings->createSetting(
+        "GAMS.SolutionsFile", "Subsolver", std::string(), "Name of GDX file to write alternative solutions to", false);
+
 #endif
 
     // Subsolver settings: Ipopt

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -1061,6 +1061,17 @@ void Solver::initializeSettings()
     env->settings->createSettingGroup("Output", "", "Solver output",
         "These settings control how much and what output is shown to the user from the solver.");
 
+    env->settings->createSetting("Console.DualSolver.Show", "Output", false, "Show output from dual solver on console");
+    
+    VectorString enumIterationDetail;
+    enumIterationDetail.push_back("Full");
+    enumIterationDetail.push_back("On objective gap update");
+    enumIterationDetail.push_back("On objective gap update and all primal NLP calls");
+    env->settings->createSetting("Console.Iteration.Detail", "Output",
+        static_cast<int>(ES_IterationOutputDetail::ObjectiveGapUpdates), "When should the fixed strategy be used",
+        enumIterationDetail, 0);
+    enumIterationDetail.clear();
+
     VectorString enumLogLevel;
     enumLogLevel.push_back("Trace");
     enumLogLevel.push_back("Debug");
@@ -1072,6 +1083,9 @@ void Solver::initializeSettings()
     env->settings->createSetting("Console.LogLevel", "Output", static_cast<int>(E_LogLevel::Info),
         "Log level for console output", enumLogLevel, 0);
 
+    env->settings->createSetting(
+        "Console.PrimalSolver.Show", "Output", false, "Show output from primal solver on console");
+
     env->settings->createSetting("Debug.Enable", "Output", false, "Use debug functionality");
 
     env->settings->createSetting(
@@ -1081,19 +1095,8 @@ void Solver::initializeSettings()
         "File.LogLevel", "Output", static_cast<int>(E_LogLevel::Info), "Log level for file output", enumLogLevel, 0);
     enumLogLevel.clear();
 
-    env->settings->createSetting("Console.DualSolver.Show", "Output", false, "Show output from dual solver on console");
     env->settings->createSetting(
-        "Console.PrimalSolver.Show", "Output", false, "Show output from primal solver on console");
-
-    VectorString enumIterationDetail;
-    enumIterationDetail.push_back("Full");
-    enumIterationDetail.push_back("On objective gap update");
-    enumIterationDetail.push_back("On objective gap update and all primal NLP calls");
-
-    env->settings->createSetting("Console.Iteration.Detail", "Output",
-        static_cast<int>(ES_IterationOutputDetail::ObjectiveGapUpdates), "When should the fixed strategy be used",
-        enumIterationDetail, 0);
-    enumIterationDetail.clear();
+        "GAMS.AlternateSolutionsFile", "Output", std::string(), "Name of GAMS GDX file to write alternative solutions to", false);
 
     VectorString enumOutputDirectory;
     enumOutputDirectory.push_back("Problem directory");
@@ -1103,7 +1106,7 @@ void Solver::initializeSettings()
     enumOutputDirectory.clear();
 
     env->settings->createSetting(
-        "SaveNumberOfSolutions", "Output", 1, "Save this number of primal solutions to OSrL file");
+        "SaveNumberOfSolutions", "Output", 1, "Save max this number of primal solutions to OSrL or GDX file");
 
     env->settings->createSettingGroup(
         "Primal", "", "Primal heuristics", "These settings control the primal heuristics used in SHOT.");
@@ -1433,10 +1436,6 @@ void Solver::initializeSettings()
     std::string solver = "auto";
     env->settings->createSetting(
         "GAMS.NLP.Solver", "Subsolver", solver, "NLP solver to use in GAMS (auto: SHOT chooses)");
-
-    env->settings->createSetting(
-        "GAMS.SolutionsFile", "Subsolver", std::string(), "Name of GDX file to write alternative solutions to", false);
-
 #endif
 
     // Subsolver settings: Ipopt


### PR DESCRIPTION
This adds writing all alternative solutions to a GDX file in the GAMS interface analogous to the (famous) `gams/dumpsolutionsmerged` option of GAMS/SCIP.

I'm assuming here that `Results::primalSolutions[0]` is the solution that is already passed back to GAMS via the usual channels. Can one assume that?