### PR TITLE
various updates for compatibility with recent and future GAMS versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -553,6 +553,7 @@ endif(HAS_IPOPT)
 if(HAS_GAMS)
     include_directories(SYSTEM "${GAMS_DIR}/apifiles/C/api")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGAMSDIR=\\\"${GAMS_DIR}\\\"")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DGC_NO_MUTEX")
 endif(HAS_GAMS)
 
 # Creates the SHOT library that is linked to the executable

--- a/src/ModelingSystem/EntryPointsGAMS.cpp
+++ b/src/ModelingSystem/EntryPointsGAMS.cpp
@@ -38,9 +38,9 @@ extern "C"
     typedef struct
     {
         gmoHandle_t gmo;
-        optHandle_t opt;
     } gamsshot;
 
+    // old+new API
     DllExport void STDCALL shtInitialize(void);
     DllExport void STDCALL shtInitialize(void)
     {
@@ -53,6 +53,7 @@ extern "C"
         palInitMutexes();
     }
 
+    // old+new API
     DllExport void STDCALL shtFinalize(void);
     DllExport void STDCALL shtFinalize(void)
     {
@@ -65,6 +66,7 @@ extern "C"
         palFiniMutexes();
     }
 
+    // old API
     DllExport int STDCALL shtcreate(void** Cptr, char* msgBuf, int msgBufLen);
     DllExport int STDCALL shtcreate(void** Cptr, char* msgBuf, int msgBufLen)
     {
@@ -94,6 +96,14 @@ extern "C"
         return 1;
     }
 
+    // new API
+    DllExport int STDCALL shtCreate(void** Cptr, char* msgBuf, int msgBufLen);
+    DllExport int STDCALL shtCreate(void** Cptr, char* msgBuf, int msgBufLen)
+    {
+       return 1-shtcreate(Cptr, msgBuf, msgBufLen);
+    }
+
+    // old API
     DllExport void STDCALL shtfree(void** Cptr);
     DllExport void STDCALL shtfree(void** Cptr)
     {
@@ -108,8 +118,16 @@ extern "C"
         palLibraryUnload();
     }
 
-    DllExport int STDCALL shtReadyAPI(void* Cptr, gmoHandle_t Gptr, optHandle_t Optr);
-    DllExport int STDCALL shtReadyAPI(void* Cptr, gmoHandle_t Gptr, optHandle_t Optr)
+    // new API
+    DllExport void STDCALL shtFree(void** Cptr);
+    DllExport void STDCALL shtFree(void** Cptr)
+    {
+       shtfree(Cptr);
+    }
+
+    // old+new API (old API ignores additional optHandle_t)
+    DllExport int STDCALL shtReadyAPI(void* Cptr, gmoHandle_t Gptr);
+    DllExport int STDCALL shtReadyAPI(void* Cptr, gmoHandle_t Gptr)
     {
         gamsshot* gs;
 
@@ -118,11 +136,11 @@ extern "C"
 
         gs = (gamsshot*)Cptr;
         gs->gmo = Gptr;
-        gs->opt = Optr;
 
         return 0;
     }
 
+    // old+new API
     DllExport int STDCALL shtCallSolver(void* Cptr);
     DllExport int STDCALL shtCallSolver(void* Cptr)
     {
@@ -132,7 +150,6 @@ extern "C"
         assert(Cptr != nullptr);
         gs = (gamsshot*)Cptr;
         assert(gs->gmo != nullptr);
-        assert(gs->opt == nullptr); /* we don't process GAMS options objects so far */
 
         // create solver, direct SHOT console output to GAMS log and status file
         Solver solver(std::make_shared<GamsOutputSink>((gevHandle_t)gmoEnvironment(gs->gmo)));
@@ -221,12 +238,15 @@ extern "C"
         return 0;
     }
 
+    // old API
     DllExport void STDCALL C__shtInitialize(void);
     DllExport void STDCALL C__shtInitialize(void) { shtInitialize(); }
 
+    // old API
     DllExport void STDCALL C__shtFinalize(void);
     DllExport void STDCALL C__shtFinalize(void) { shtFinalize(); }
 
+    // old API
     DllExport void STDCALL shtXCreate(void** Cptr);
     DllExport void STDCALL shtXCreate(void** Cptr)
     {
@@ -234,18 +254,22 @@ extern "C"
         shtcreate(Cptr, msg, sizeof(msg));
     }
 
+    // old API
     DllExport void STDCALL shtXFree(void** Cptr);
     DllExport void STDCALL shtXFree(void** Cptr) { shtfree(Cptr); }
 
+    // old API
     DllExport int STDCALL C__shtReadyAPI(void* Cptr, struct gmoRec* Gptr, struct optRec* Optr);
     DllExport int STDCALL C__shtReadyAPI(void* Cptr, struct gmoRec* Gptr, struct optRec* Optr)
     {
-        return shtReadyAPI(Cptr, Gptr, Optr);
+        return shtReadyAPI(Cptr, Gptr);
     }
 
+    // old API
     DllExport int STDCALL C__shtCallSolver(void* Cptr);
     DllExport int STDCALL C__shtCallSolver(void* Cptr) { return shtCallSolver(Cptr); }
 
+    // old API
     DllExport int STDCALL C__shtXAPIVersion(int api, char* Msg, int* comp);
     DllExport int STDCALL C__shtXAPIVersion([[maybe_unused]] int api, [[maybe_unused]] char* Msg, int* comp)
     {
@@ -253,6 +277,7 @@ extern "C"
         return 1;
     }
 
+    // old API
     DllExport int STDCALL D__shtXAPIVersion(int api, char* Msg, int* comp);
     DllExport int STDCALL D__shtXAPIVersion([[maybe_unused]] int api, [[maybe_unused]] char* Msg, int* comp)
     {
@@ -260,6 +285,7 @@ extern "C"
         return 1;
     }
 
+    // old API
     DllExport int STDCALL C__shtXCheck(const char* funcn, int ClNrArg, int Clsign[], char* Msg);
     DllExport int STDCALL C__shtXCheck([[maybe_unused]] const char* funcn, [[maybe_unused]] int ClNrArg,
         [[maybe_unused]] int Clsign[], [[maybe_unused]] char* Msg)
@@ -267,6 +293,7 @@ extern "C"
         return 1;
     }
 
+    // old API
     DllExport int STDCALL D__shtXCheck(const char* funcn, int ClNrArg, int Clsign[], char* Msg);
     DllExport int STDCALL D__shtXCheck([[maybe_unused]] const char* funcn, [[maybe_unused]] int ClNrArg,
         [[maybe_unused]] int Clsign[], [[maybe_unused]] char* Msg)

--- a/src/ModelingSystem/IModelingSystem.h
+++ b/src/ModelingSystem/IModelingSystem.h
@@ -31,11 +31,11 @@ enum class E_ProblemCreationStatus
 class IModelingSystem
 {
 public:
-    IModelingSystem(EnvironmentPtr envPtr) : env(envPtr){};
-    virtual ~IModelingSystem()= default;
+    IModelingSystem(EnvironmentPtr envPtr) : env(envPtr) {};
+    virtual ~IModelingSystem() = default;
 
     // Adds modeling system specific settings
-    virtual void augmentSettings(SettingsPtr settings) = 0;
+    static void augmentSettings([[maybe_unused]] SettingsPtr settings) {};
 
     // Get specific settings from modeling system
     virtual void updateSettings(SettingsPtr settings) = 0;

--- a/src/ModelingSystem/ModelingSystemAMPL.cpp
+++ b/src/ModelingSystem/ModelingSystemAMPL.cpp
@@ -434,13 +434,13 @@ public:
     }
 };
 
-ModelingSystemAMPL::ModelingSystemAMPL(EnvironmentPtr envPtr) : IModelingSystem(envPtr) {}
+ModelingSystemAMPL::ModelingSystemAMPL(EnvironmentPtr envPtr) : IModelingSystem(envPtr) { }
 
 ModelingSystemAMPL::~ModelingSystemAMPL() = default;
 
-void ModelingSystemAMPL::augmentSettings([[maybe_unused]] SettingsPtr settings) {}
+void ModelingSystemAMPL::augmentSettings([[maybe_unused]] SettingsPtr settings) { }
 
-void ModelingSystemAMPL::updateSettings([[maybe_unused]] SettingsPtr settings) {}
+void ModelingSystemAMPL::updateSettings([[maybe_unused]] SettingsPtr settings) { }
 
 E_ProblemCreationStatus ModelingSystemAMPL::createProblem(ProblemPtr& problem, const std::string& filename)
 {
@@ -515,6 +515,6 @@ E_ProblemCreationStatus ModelingSystemAMPL::createProblem(ProblemPtr& problem, c
     return (E_ProblemCreationStatus::NormalCompletion);
 }
 
-void ModelingSystemAMPL::finalizeSolution() {}
+void ModelingSystemAMPL::finalizeSolution() { }
 
 } // Namespace SHOT

--- a/src/ModelingSystem/ModelingSystemAMPL.h
+++ b/src/ModelingSystem/ModelingSystemAMPL.h
@@ -27,7 +27,7 @@ public:
     ~ModelingSystemAMPL() override;
 
     // Adds modeling system specific settings
-    void augmentSettings(SettingsPtr settings) override;
+    static void augmentSettings(SettingsPtr settings);
 
     // Get specific settings from modeling system
     void updateSettings(SettingsPtr settings) override;

--- a/src/ModelingSystem/ModelingSystemGAMS.cpp
+++ b/src/ModelingSystem/ModelingSystemGAMS.cpp
@@ -78,7 +78,20 @@ ModelingSystemGAMS::~ModelingSystemGAMS()
     }
 }
 
-void ModelingSystemGAMS::augmentSettings([[maybe_unused]] SettingsPtr settings) {}
+void ModelingSystemGAMS::augmentSettings([[maybe_unused]] SettingsPtr settings)
+{
+#if GMOAPIVERSION >= 21
+    env->settings->createSettingGroup(
+        "ModelingSystem", "GAMS", "GAMS interface", "These settings control functionality used in the GAMS interface.");
+
+    VectorString enumQExtractAlg;
+    enumQExtractAlg.push_back("automatic");
+    enumQExtractAlg.push_back("threepass");
+    enumQExtractAlg.push_back("doubleforward");
+    env->settings->createSetting("GAMS.QExtractAlg", "ModelingSystem", 0,
+        "Extraction algorithm for quadratic equations in GAMS interface", enumQExtractAlg);
+#endif
+}
 
 void ModelingSystemGAMS::updateSettings(SettingsPtr settings)
 {
@@ -156,14 +169,6 @@ void ModelingSystemGAMS::updateSettings(SettingsPtr settings)
         // below)
         env->settings->updateSetting("FixedInteger.Solver", "Primal", static_cast<int>(ES_PrimalNLPSolver::GAMS));
     }
-
-#if GMOAPIVERSION >= 21
-    VectorString enumQExtractAlg;
-    enumQExtractAlg.push_back("automatic");
-    enumQExtractAlg.push_back("threepass");
-    enumQExtractAlg.push_back("doubleforward");
-    env->settings->createSetting("QExtractAlg", "Model", 0, "Extraction algorithm for quadratic equations in GAMS interface", enumQExtractAlg);
-#endif
 
     if(gmoOptFile(modelingObject) > 0) // GAMS provides an option file
     {
@@ -256,7 +261,8 @@ E_ProblemCreationStatus ModelingSystemGAMS::createProblem(ProblemPtr& problem)
 #endif
     gmoUseQSet(modelingObject, 1);
 #if GMOAPIVERSION >= 21
-    env->output->outputInfo(std::string(" Time to extract information on quadratics: ") + std::to_string(gevTimeDiff(modelingEnvironment)));
+    env->output->outputInfo(
+        std::string(" Time to extract information on quadratics: ") + std::to_string(gevTimeDiff(modelingEnvironment)));
 #endif
 
     try

--- a/src/ModelingSystem/ModelingSystemGAMS.cpp
+++ b/src/ModelingSystem/ModelingSystemGAMS.cpp
@@ -82,25 +82,24 @@ void ModelingSystemGAMS::augmentSettings([[maybe_unused]] SettingsPtr settings)
 {
     // Subsolver settings: GAMS NLP
 
-    env->settings->createSettingGroup("Subsolver", "GAMS", "GAMS", "Settings for the GAMS NLP solvers.");
+    settings->createSettingGroup("Subsolver", "GAMS", "GAMS", "Settings for the GAMS NLP solvers.");
 
     std::string optfile = "";
-    env->settings->createSetting(
+    settings->createSetting(
         "GAMS.NLP.OptionsFilename", "Subsolver", optfile, "Options file for the NLP solver in GAMS");
 
     std::string solver = "auto";
-    env->settings->createSetting(
-        "GAMS.NLP.Solver", "Subsolver", solver, "NLP solver to use in GAMS (auto: SHOT chooses)");
+    settings->createSetting("GAMS.NLP.Solver", "Subsolver", solver, "NLP solver to use in GAMS (auto: SHOT chooses)");
 
 #if GMOAPIVERSION >= 21
-    env->settings->createSettingGroup(
+    settings->createSettingGroup(
         "ModelingSystem", "GAMS", "GAMS interface", "These settings control functionality used in the GAMS interface.");
 
     VectorString enumQExtractAlg;
     enumQExtractAlg.push_back("automatic");
     enumQExtractAlg.push_back("threepass");
     enumQExtractAlg.push_back("doubleforward");
-    env->settings->createSetting("GAMS.QExtractAlg", "ModelingSystem", 0,
+    settings->createSetting("GAMS.QExtractAlg", "ModelingSystem", 0,
         "Extraction algorithm for quadratic equations in GAMS interface", enumQExtractAlg);
 #endif
 }

--- a/src/ModelingSystem/ModelingSystemGAMS.cpp
+++ b/src/ModelingSystem/ModelingSystemGAMS.cpp
@@ -1032,13 +1032,21 @@ bool ModelingSystemGAMS::copyQuadraticTerms(ProblemPtr destination)
 
     if(gmoGetObjOrder(modelingObject) == gmoorder_Q)
     {
+#if GMOAPIVERSION <= 19
         int numQuadraticTerms = gmoObjQNZ(modelingObject);
+#else
+        int numQuadraticTerms = gmoObjQMatNZ(modelingObject);
+#endif
 
         int* variableOneIndexes = new int[numQuadraticTerms];
         int* variableTwoIndexes = new int[numQuadraticTerms];
         double* quadraticCoefficients = new double[numQuadraticTerms];
 
+#if GMOAPIVERSION <= 19
         gmoGetObjQ(modelingObject, variableOneIndexes, variableTwoIndexes, quadraticCoefficients);
+#else
+        gmoGetObjQMat(modelingObject, variableOneIndexes, variableTwoIndexes, quadraticCoefficients);
+#endif
 
         for(int j = 0; j < numQuadraticTerms; ++j)
         {
@@ -1083,7 +1091,11 @@ bool ModelingSystemGAMS::copyQuadraticTerms(ProblemPtr destination)
             int* variableTwoIndexes = new int[numQuadraticTerms];
             double* quadraticCoefficients = new double[numQuadraticTerms];
 
+#if GMOAPIVERSION <= 19
             gmoGetRowQ(modelingObject, i, variableOneIndexes, variableTwoIndexes, quadraticCoefficients);
+#else
+            gmoGetRowQMat(modelingObject, i, variableOneIndexes, variableTwoIndexes, quadraticCoefficients);
+#endif
 
             for(int j = 0; j < numQuadraticTerms; ++j)
             {

--- a/src/ModelingSystem/ModelingSystemGAMS.cpp
+++ b/src/ModelingSystem/ModelingSystemGAMS.cpp
@@ -333,18 +333,18 @@ void ModelingSystemGAMS::createModelFromProblemFile(const std::string& filename)
 
     createdtmpdir = true;
 
-    /* create empty convertd options file */
-    std::ofstream convertdopt((fs::filesystem::path(tmpdirname) / "convertd.opt").string(), std::ios::out);
+    /* create empty convert options file */
+    std::ofstream convertopt((fs::filesystem::path(tmpdirname) / "convert.opt").string(), std::ios::out);
 
-    if(!convertdopt.good())
+    if(!convertopt.good())
     {
-        throw std::logic_error("Could not create convertd options file.");
+        throw std::logic_error("Could not create convert options file.");
     }
 
-    convertdopt << " " << std::endl;
-    convertdopt.close();
+    convertopt << " " << std::endl;
+    convertopt.close();
 
-    /* call GAMS with convertd solver to get compiled model instance in temporary directory
+    /* call GAMS with convert solver to get compiled model instance in temporary directory
      * we set lo=3 so that we get lo=3 into the gams control file, which is useful for showing the log of GAMS (NLP)
      * solvers later but since we don't want to see the stdout output from gams here, we redirect stdout to /dev/null
      * for this gams call
@@ -356,7 +356,7 @@ void ModelingSystemGAMS::createModelFromProblemFile(const std::string& filename)
     gamscall = "gams";
 #endif
     gamscall += " \"" + filename + "\"";
-    gamscall += " SOLVER=CONVERTD PF4=0 SOLPRINT=0 LIMCOL=0 LIMROW=0 PC=2";
+    gamscall += " SOLVER=CONVERT PF4=0 SOLPRINT=0 LIMCOL=0 LIMROW=0 PC=2";
     gamscall += " SCRDIR=" + tmpdirname;
     gamscall += " OUTPUT=" + (fs::filesystem::path(tmpdirname) / "listing").string();
     gamscall += " OPTFILE=1 OPTDIR=" + tmpdirname;
@@ -454,7 +454,7 @@ void ModelingSystemGAMS::createModelFromProblemFile(const std::string& filename)
 
     createModelFromGAMSModel((fs::filesystem::path(tmpdirname) / "gamscntr.dat").string());
 
-    /* since we ran convert with options file, GMO now stores convertd.opt as options file, which we don't want to use
+    /* since we ran convert with options file, GMO now stores convert.opt as options file, which we don't want to use
      * as a SHOT options file */
     gmoOptFileSet(modelingObject, 0);
 

--- a/src/ModelingSystem/ModelingSystemGAMS.cpp
+++ b/src/ModelingSystem/ModelingSystemGAMS.cpp
@@ -268,7 +268,7 @@ E_ProblemCreationStatus ModelingSystemGAMS::createProblem(ProblemPtr& problem)
     gmoIndexBaseSet(modelingObject, 0);
 
 #if GMOAPIVERSION >= 21
-    gmoQExtractAlgSet(modelingObject, env->settings->getSetting<int>("QExtractAlg", "Model"));
+    gmoQExtractAlgSet(modelingObject, env->settings->getSetting<int>("GAMS.QExtractAlg", "ModelingSystem"));
     gevTimeDiff(modelingEnvironment);
 #endif
     gmoUseQSet(modelingObject, 1);

--- a/src/ModelingSystem/ModelingSystemGAMS.cpp
+++ b/src/ModelingSystem/ModelingSystemGAMS.cpp
@@ -80,6 +80,18 @@ ModelingSystemGAMS::~ModelingSystemGAMS()
 
 void ModelingSystemGAMS::augmentSettings([[maybe_unused]] SettingsPtr settings)
 {
+    // Subsolver settings: GAMS NLP
+
+    env->settings->createSettingGroup("Subsolver", "GAMS", "GAMS", "Settings for the GAMS NLP solvers.");
+
+    std::string optfile = "";
+    env->settings->createSetting(
+        "GAMS.NLP.OptionsFilename", "Subsolver", optfile, "Options file for the NLP solver in GAMS");
+
+    std::string solver = "auto";
+    env->settings->createSetting(
+        "GAMS.NLP.Solver", "Subsolver", solver, "NLP solver to use in GAMS (auto: SHOT chooses)");
+
 #if GMOAPIVERSION >= 21
     env->settings->createSettingGroup(
         "ModelingSystem", "GAMS", "GAMS interface", "These settings control functionality used in the GAMS interface.");

--- a/src/ModelingSystem/ModelingSystemGAMS.cpp
+++ b/src/ModelingSystem/ModelingSystemGAMS.cpp
@@ -157,6 +157,14 @@ void ModelingSystemGAMS::updateSettings(SettingsPtr settings)
         env->settings->updateSetting("FixedInteger.Solver", "Primal", static_cast<int>(ES_PrimalNLPSolver::GAMS));
     }
 
+#if GMOAPIVERSION >= 21
+    VectorString enumQExtractAlg;
+    enumQExtractAlg.push_back("automatic");
+    enumQExtractAlg.push_back("threepass");
+    enumQExtractAlg.push_back("doubleforward");
+    env->settings->createSetting("QExtractAlg", "Model", 0, "Extraction algorithm for quadratic equations in GAMS interface", enumQExtractAlg);
+#endif
+
     if(gmoOptFile(modelingObject) > 0) // GAMS provides an option file
     {
         gmoNameOptFile(modelingObject, buffer);
@@ -241,7 +249,15 @@ E_ProblemCreationStatus ModelingSystemGAMS::createProblem(ProblemPtr& problem)
     gmoMinfSet(modelingObject, SHOT_DBL_MIN);
     gmoPinfSet(modelingObject, SHOT_DBL_MAX);
     gmoIndexBaseSet(modelingObject, 0);
+
+#if GMOAPIVERSION >= 21
+    gmoQExtractAlgSet(modelingObject, env->settings->getSetting<int>("QExtractAlg", "Model"));
+    gevTimeDiff(modelingEnvironment);
+#endif
     gmoUseQSet(modelingObject, 1);
+#if GMOAPIVERSION >= 21
+    env->output->outputInfo(std::string(" Time to extract information on quadratics: ") + std::to_string(gevTimeDiff(modelingEnvironment)));
+#endif
 
     try
     {

--- a/src/ModelingSystem/ModelingSystemGAMS.h
+++ b/src/ModelingSystem/ModelingSystemGAMS.h
@@ -43,7 +43,7 @@ public:
     void setModelingObject(gmoHandle_t gmo);
 
     // Adds modeling system specific settings
-    void augmentSettings(SettingsPtr settings) override;
+    static void augmentSettings(SettingsPtr settings);
 
     // Get specific settings from modeling system
     void updateSettings(SettingsPtr settings) override;
@@ -100,7 +100,7 @@ private:
     GamsOutputSink() = delete;
 
 public:
-    GamsOutputSink(gevHandle_t gev_) : gev(gev_) {}
+    GamsOutputSink(gevHandle_t gev_) : gev(gev_) { }
 
     void sink_it_(const spdlog::details::log_msg& msg) override
     {

--- a/src/ModelingSystem/ModelingSystemOS.cpp
+++ b/src/ModelingSystem/ModelingSystemOS.cpp
@@ -43,13 +43,13 @@ namespace fs = std::experimental;
 namespace SHOT
 {
 
-ModelingSystemOS::ModelingSystemOS(EnvironmentPtr envPtr) : IModelingSystem(envPtr) {}
+ModelingSystemOS::ModelingSystemOS(EnvironmentPtr envPtr) : IModelingSystem(envPtr) { }
 
 ModelingSystemOS::~ModelingSystemOS() = default;
 
-void ModelingSystemOS::augmentSettings([[maybe_unused]] SettingsPtr settings) {}
+void ModelingSystemOS::augmentSettings([[maybe_unused]] SettingsPtr settings) { }
 
-void ModelingSystemOS::updateSettings([[maybe_unused]] SettingsPtr settings) {}
+void ModelingSystemOS::updateSettings([[maybe_unused]] SettingsPtr settings) { }
 
 E_ProblemCreationStatus ModelingSystemOS::createProblem(
     ProblemPtr& problem, const std::string& filename, const E_OSInputFileFormat& type)
@@ -141,7 +141,7 @@ E_ProblemCreationStatus ModelingSystemOS::createProblem(ProblemPtr& problem, std
     return (E_ProblemCreationStatus::NormalCompletion);
 }
 
-void ModelingSystemOS::finalizeSolution() {}
+void ModelingSystemOS::finalizeSolution() { }
 
 OSInstance* ModelingSystemOS::readInstanceFromOSiL(const std::string& text)
 {

--- a/src/ModelingSystem/ModelingSystemOS.h
+++ b/src/ModelingSystem/ModelingSystemOS.h
@@ -43,7 +43,7 @@ public:
     ~ModelingSystemOS() override;
 
     // Adds modeling system specific settings
-    void augmentSettings(SettingsPtr settings) override;
+    static void augmentSettings(SettingsPtr settings);
 
     // Get specific settings from modeling system
     void updateSettings(SettingsPtr settings) override;

--- a/src/ModelingSystem/ModelingSystemOSiL.cpp
+++ b/src/ModelingSystem/ModelingSystemOSiL.cpp
@@ -31,13 +31,13 @@ namespace fs = std::experimental;
 namespace SHOT
 {
 
-ModelingSystemOSiL::ModelingSystemOSiL(EnvironmentPtr envPtr) : IModelingSystem(envPtr) {}
+ModelingSystemOSiL::ModelingSystemOSiL(EnvironmentPtr envPtr) : IModelingSystem(envPtr) { }
 
 ModelingSystemOSiL::~ModelingSystemOSiL() = default;
 
-void ModelingSystemOSiL::augmentSettings([[maybe_unused]] SettingsPtr settings) {}
+void ModelingSystemOSiL::augmentSettings([[maybe_unused]] SettingsPtr settings) { }
 
-void ModelingSystemOSiL::updateSettings([[maybe_unused]] SettingsPtr settings) {}
+void ModelingSystemOSiL::updateSettings([[maybe_unused]] SettingsPtr settings) { }
 
 E_ProblemCreationStatus ModelingSystemOSiL::createProblem(ProblemPtr& problem, const std::string& filename)
 {
@@ -600,6 +600,6 @@ NonlinearExpressionPtr ModelingSystemOSiL::convertNonlinearNode(tinyxml2::XMLNod
     return nullptr;
 }
 
-void ModelingSystemOSiL::finalizeSolution() {}
+void ModelingSystemOSiL::finalizeSolution() { }
 
 } // Namespace SHOT

--- a/src/ModelingSystem/ModelingSystemOSiL.h
+++ b/src/ModelingSystem/ModelingSystemOSiL.h
@@ -36,7 +36,7 @@ public:
     ~ModelingSystemOSiL() override;
 
     // Adds modeling system specific settings
-    void augmentSettings(SettingsPtr settings) override;
+    static void augmentSettings(SettingsPtr settings);
 
     // Get specific settings from modeling system
     void updateSettings(SettingsPtr settings) override;

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -1486,23 +1486,15 @@ void Solver::initializeSettings()
     env->settings->createSetting("ResultPath", "Output", empty, "The path where to save the result information", true);
 
     // Need to create the modeling systems temporary to get their settings
-    {
-        auto modelingSystem = std::make_shared<ModelingSystemOSiL>(env);
-        modelingSystem->augmentSettings(env->settings);
-    }
+
+    ModelingSystemOSiL::augmentSettings(env->settings);
 
 #ifdef HAS_AMPL
-    {
-        auto modelingSystem = std::make_shared<ModelingSystemAMPL>(env);
-        modelingSystem->augmentSettings(env->settings);
-    }
+    ModelingSystemAMPL::augmentSettings(env->settings);
 #endif
 
 #ifdef HAS_GAMS
-    {
-        auto modelingSystem = std::make_shared<ModelingSystemGAMS>(env);
-        modelingSystem->augmentSettings(env->settings);
-    }
+    ModelingSystemGAMS::augmentSettings(env->settings);
 #endif
 
     env->settings->settingsInitialized = true;

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -1020,6 +1020,11 @@ void Solver::initializeSettings()
         "How to treat quadratic functions", enumQPStrategy, 0);
     enumQPStrategy.clear();
 
+    // Modeling system settings
+
+    env->settings->createSettingGroup("ModelingSystem", "", "Modeling system",
+        "These settings control functionality used in the interfaces to different modeling environments.");
+
     // Logging and output settings
 
     env->settings->createSettingGroup("Output", "", "Solver output",
@@ -1377,22 +1382,6 @@ void Solver::initializeSettings()
     enumStrategy.push_back("aggressive");
     env->settings->createSetting("Cbc.Strategy", "Subsolver", 1, "This turns on newer features", enumStrategy, 0);
     enumStrategy.clear();
-
-#endif
-
-    // Subsolver settings: GAMS NLP
-
-#ifdef HAS_GAMS
-
-    env->settings->createSettingGroup("Subsolver", "GAMS", "GAMS", "Settings for the GAMS NLP solvers.");
-
-    std::string optfile = "";
-    env->settings->createSetting(
-        "GAMS.NLP.OptionsFilename", "Subsolver", optfile, "Options file for the NLP solver in GAMS");
-
-    std::string solver = "auto";
-    env->settings->createSetting(
-        "GAMS.NLP.Solver", "Subsolver", solver, "NLP solver to use in GAMS (auto: SHOT chooses)");
 
 #endif
 

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -1496,6 +1496,26 @@ void Solver::initializeSettings()
 
     env->settings->createSetting("ResultPath", "Output", empty, "The path where to save the result information", true);
 
+    // Need to create the modeling systems temporary to get their settings
+    {
+        auto modelingSystem = std::make_shared<ModelingSystemOSiL>(env);
+        modelingSystem->augmentSettings(env->settings);
+    }
+
+#ifdef HAS_AMPL
+    {
+        auto modelingSystem = std::make_shared<ModelingSystemAMPL>(env);
+        modelingSystem->augmentSettings(env->settings);
+    }
+#endif
+
+#ifdef HAS_GAMS
+    {
+        auto modelingSystem = std::make_shared<ModelingSystemGAMS>(env);
+        modelingSystem->augmentSettings(env->settings);
+    }
+#endif
+
     env->settings->settingsInitialized = true;
 
     env->output->outputDebug(" Initialization of settings complete.");
@@ -1571,7 +1591,7 @@ void Solver::verifySettings()
            == ES_PrimalNLPSolver::GAMS)
         && (static_cast<ES_PrimalNLPProblemSource>(
                 env->settings->getSetting<int>("FixedInteger.SourceProblem", "Primal"))
-               != ES_PrimalNLPProblemSource::OriginalProblem))
+            != ES_PrimalNLPProblemSource::OriginalProblem))
     {
         env->output->outputWarning(" Cannot use GAMS NLP solvers when solving fixed NLP problems based on the "
                                    "reformulated model. Use Ipopt instead!");


### PR DESCRIPTION
- define GC_NO_MUTEX for compatibilty with API files of GAMS >= 33
- do not use GMO functions that were deprecated in GAMS 35
-  use Convert instead of ConvertD
    - should not really matter which one is used, but ConvertD is only synonym
      for Convert since GAMS 34
-  add ~~Model.QExtractAlg~~ModelingSystem.GAMS.QExtractAlg option to specify how useQSet should work if GAMS >= 36
-  support updated solverlink API from GAMS 36
