### PR TITLE
fix handling of semicontinuous variables; add support for semiinteger variables

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -60,7 +60,7 @@ jobs:
       if: steps.cache-cbc.outputs.cache-hit != 'true'
       shell: bash
       working-directory: ${{runner.workspace}}/build/coinbrew
-      run: ./coinbrew build Cbc --verbosity 2 --prefix=${{runner.workspace}}/ThirdParty/Cbc --no-prompt --tests none
+      run: ./coinbrew build Cbc --verbosity 2 --prefix=${{runner.workspace}}/ThirdParty/Cbc --no-prompt --tests none --no-third-party
 
     - name: Configure CMake
       # Use a bash shell so we can use the same syntax for environment variable

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_script:
   - bash ./coinbrew build Ipopt --verbosity 2 --prefix=/home/travis/build/coin-or/SHOT/ThirdParty/Ipopt --no-prompt --tests none
   - rm build -rf
   - mkdir /home/travis/build/coin-or/SHOT/ThirdParty/Cbc
-  - bash ./coinbrew build Cbc --no-third-party --prefix=/home/travis/build/coin-or/SHOT/ThirdParty/Cbc --no-prompt --tests none
+  - bash ./coinbrew build Cbc --no-third-party --prefix=/home/travis/build/coin-or/SHOT/ThirdParty/Cbc --no-prompt --tests none --no-third-party
   - mkdir /home/travis/build/coin-or/SHOT/build
   - cd /home/travis/build/coin-or/SHOT/build
   - cmake .. -DHAS_CBC=on -DCBC_DIR=/home/travis/build/coin-or/SHOT/ThirdParty/Cbc -DHAS_IPOPT=ON -DIPOPT_DIR=/home/travis/build/coin-or/SHOT/ThirdParty/Ipopt -DHAS_GAMS=off -DHAS_CPLEX=off -DHAS_GUROBI=off -DCOMPILE_TESTS=on -DSPDLOG_STATIC=off

--- a/src/DualSolver.cpp
+++ b/src/DualSolver.cpp
@@ -257,7 +257,7 @@ bool DualSolver::hasHyperplaneBeenAdded(double hash, int constraintIndex)
 
 void DualSolver::addIntegerCut(IntegerCut integerCut)
 {
-    if(env->reformulatedProblem->properties.numberOfIntegerVariables > 0)
+    if(env->reformulatedProblem->properties.numberOfIntegerVariables > 0 || env->reformulatedProblem->properties.numberOfSemiintegerVariables > 0)
         integerCut.areAllVariablesBinary = false;
     else
     {

--- a/src/Enums.h
+++ b/src/Enums.h
@@ -260,7 +260,8 @@ enum class E_VariableType
     Real,
     Binary,
     Integer,
-    Semicontinuous
+    Semicontinuous,
+    Semiinteger
 };
 
 enum class ES_AddPrimalPointAsInteriorPoint

--- a/src/MIPSolver/IMIPSolver.h
+++ b/src/MIPSolver/IMIPSolver.h
@@ -30,7 +30,7 @@ public:
     virtual bool initializeProblem() = 0;
     virtual void checkParameters() = 0;
 
-    virtual bool addVariable(std::string name, E_VariableType type, double lowerBound, double upperBound) = 0;
+    virtual bool addVariable(std::string name, E_VariableType type, double lowerBound, double upperBound, double semiBound) = 0;
 
     virtual bool initializeObjective() = 0;
     virtual bool addLinearTermToObjective(double coefficient, int variableIndex) = 0;

--- a/src/MIPSolver/MIPSolverBase.cpp
+++ b/src/MIPSolver/MIPSolverBase.cpp
@@ -46,7 +46,8 @@ bool MIPSolverBase::getDiscreteVariableStatus()
 {
     if(env->reformulatedProblem->properties.numberOfDiscreteVariables == 0
         && env->reformulatedProblem->properties.numberOfSemicontinuousVariables == 0
-        && env->reformulatedProblem->properties.numberOfSpecialOrderedSets == 0)
+        && env->reformulatedProblem->properties.numberOfSpecialOrderedSets == 0
+        && env->reformulatedProblem->properties.numberOfSemiintegerVariables == 0)
     {
         return (false);
     }

--- a/src/MIPSolver/MIPSolverCbc.cpp
+++ b/src/MIPSolver/MIPSolverCbc.cpp
@@ -122,6 +122,8 @@ bool MIPSolverCbc::addVariable(std::string name, E_VariableType type, double low
             coinModel->setInteger(index);
             break;
 
+        case E_VariableType::Semiinteger:
+            coinModel->setInteger(index);
         case E_VariableType::Semicontinuous:
         {
             // variable is either {0} or in [semiBound,upperBound]

--- a/src/MIPSolver/MIPSolverCbc.cpp
+++ b/src/MIPSolver/MIPSolverCbc.cpp
@@ -457,7 +457,7 @@ void MIPSolverCbc::activateDiscreteVariables(bool activate)
 
         for(int i = 0; i < numberOfVariables; i++)
         {
-            if(variableTypes.at(i) == E_VariableType::Integer || variableTypes.at(i) == E_VariableType::Binary)
+            if(variableTypes.at(i) == E_VariableType::Integer || variableTypes.at(i) == E_VariableType::Binary || variableTypes.at(i) == E_VariableType::Semiinteger)
             {
                 osiInterface->setInteger(i);
                 assert(osiInterface->isInteger(i));
@@ -471,7 +471,7 @@ void MIPSolverCbc::activateDiscreteVariables(bool activate)
         env->output->outputDebug("        Activating LP strategy");
         for(int i = 0; i < numberOfVariables; i++)
         {
-            if(variableTypes.at(i) == E_VariableType::Integer || variableTypes.at(i) == E_VariableType::Binary)
+            if(variableTypes.at(i) == E_VariableType::Integer || variableTypes.at(i) == E_VariableType::Binary || variableTypes.at(i) == E_VariableType::Semiinteger)
             {
                 osiInterface->setContinuous(i);
                 assert(osiInterface->isContinuous(i));
@@ -1353,7 +1353,7 @@ bool MIPSolverCbc::createIntegerCut(IntegerCut& integerCut)
 
             for(auto& VAR : env->reformulatedProblem->allVariables)
             {
-                if(!(VAR->properties.type == E_VariableType::Binary || VAR->properties.type == E_VariableType::Integer))
+                if(!(VAR->properties.type == E_VariableType::Binary || VAR->properties.type == E_VariableType::Integer || VAR->properties.type == E_VariableType::Semiinteger))
                     continue;
 
                 int variableValue = integerCut.variableValues[index];
@@ -1396,7 +1396,7 @@ bool MIPSolverCbc::createIntegerCut(IntegerCut& integerCut)
                 int variableValue = integerCut.variableValues[index];
 
                 assert(
-                    VAR->properties.type == E_VariableType::Binary || VAR->properties.type == E_VariableType::Integer);
+                    VAR->properties.type == E_VariableType::Binary || VAR->properties.type == E_VariableType::Integer || VAR->properties.type == E_VariableType::Semiinteger);
 
                 if(variableValue == VAR->upperBound)
                 {

--- a/src/MIPSolver/MIPSolverCbc.cpp
+++ b/src/MIPSolver/MIPSolverCbc.cpp
@@ -676,8 +676,13 @@ E_ProblemSolutionStatus MIPSolverCbc::solveProblem()
 
         initializeSolverSettings();
 
-        // Adding the MIP start provided
-        if(isProblemDiscrete)
+        // Adding the MIP start provided, so far only if there are no special variable types included, since the MIP
+        // start functionality in Cbc version 2 is unstable
+        if(MIPStart.size() > 0
+            && (env->reformulatedProblem->properties.numberOfSemiintegerVariables
+                    + env->reformulatedProblem->properties.numberOfSemicontinuousVariables
+                    + env->reformulatedProblem->properties.numberOfSpecialOrderedSets
+                == 0))
             cbcModel->setMIPStart(MIPStart);
 
         CbcSolverUsefulData solverData;

--- a/src/MIPSolver/MIPSolverCbc.cpp
+++ b/src/MIPSolver/MIPSolverCbc.cpp
@@ -289,25 +289,6 @@ bool MIPSolverCbc::finalizeProblem()
         osiInterface->loadFromCoinModel(*coinModel);
         cbcModel = std::make_unique<CbcModel>(*osiInterface);
 
-        // create and add lotsize objects
-        if(!lotsizes.empty())
-        {
-            std::vector<CbcObject*> cbcobjects;
-            cbcobjects.reserve(lotsizes.size());
-            for(const auto& l : lotsizes)
-            {
-                if(l.second[2] == l.second[3]) // special case where second interval is singleton, too
-                    cbcobjects.push_back(new CbcLotsize(cbcModel.get(), l.first, 2, l.second.data() + 1, false));
-                else
-                    cbcobjects.push_back(new CbcLotsize(cbcModel.get(), l.first, 2, l.second.data(), true));
-            }
-
-            cbcModel->addObjects(cbcobjects.size(), cbcobjects.data());
-
-            for(CbcObject* o : cbcobjects)
-                delete o;
-        }
-
         CbcSolverUsefulData solverData;
         CbcMain0(*cbcModel, solverData);
 
@@ -684,6 +665,26 @@ E_ProblemSolutionStatus MIPSolverCbc::solveProblem()
                     + env->reformulatedProblem->properties.numberOfSpecialOrderedSets
                 == 0))
             cbcModel->setMIPStart(MIPStart);
+
+        // Create and add lotsize objects
+        if(!lotsizes.empty())
+        {
+            std::vector<CbcObject*> cbcobjects;
+            cbcobjects.reserve(lotsizes.size());
+
+            for(const auto& l : lotsizes)
+            {
+                if(l.second[2] == l.second[3]) // special case where second interval is singleton, too
+                    cbcobjects.push_back(new CbcLotsize(cbcModel.get(), l.first, 2, l.second.data() + 1, false));
+                else
+                    cbcobjects.push_back(new CbcLotsize(cbcModel.get(), l.first, 2, l.second.data(), true));
+            }
+
+            cbcModel->addObjects(cbcobjects.size(), cbcobjects.data());
+
+            for(CbcObject* o : cbcobjects)
+                delete o;
+        }
 
         CbcSolverUsefulData solverData;
         CbcMain0(*cbcModel, solverData);

--- a/src/MIPSolver/MIPSolverCbc.cpp
+++ b/src/MIPSolver/MIPSolverCbc.cpp
@@ -27,6 +27,7 @@
 #include "CoinPragma.hpp"
 #include "CbcModel.hpp"
 #include "CbcSolver.hpp"
+#include "CbcBranchLotsize.hpp"
 #include "OsiClpSolverInterface.hpp"
 
 namespace SHOT
@@ -123,7 +124,7 @@ bool MIPSolverCbc::addVariable(std::string name, E_VariableType type, double low
 
         case E_VariableType::Semicontinuous:
             isProblemDiscrete = true;
-            coinModel->setInteger(index);
+            ++numberOfSemiVars;
             break;
 
         default:
@@ -273,6 +274,64 @@ bool MIPSolverCbc::finalizeProblem()
     {
         osiInterface->loadFromCoinModel(*coinModel);
         cbcModel = std::make_unique<CbcModel>(*osiInterface);
+
+        // assemble semicontinuous and semiinteger variables
+        if(numberOfSemiVars > 0)
+        {
+           CbcObject** semiobjects = new CbcObject*[numberOfSemiVars];
+           int object_nr = 0;
+           double points[4];
+           points[0] = 0.;
+           points[1] = 0.;
+           for( size_t i = 0; i < variableTypes.size(); ++i )
+           {
+               if( variableTypes[i] != E_VariableType::Semicontinuous )
+                   continue;
+
+              double varlb = coinModel->columnLower(i);
+              double varub = coinModel->columnUpper(i);
+
+#if 0
+              if( vartype == gmovar_SI && varub - varlb <= 1000 )
+              {
+                 // model lotsize for discrete variable as a set of integer values
+                 int len = (int)(varub - varlb + 2);
+                 double* points2 = new double[len];
+                 points2[0] = 0.;
+                 int j = 1;
+                 for( int p = (int)varlb; p <= varub; ++p, ++j )
+                    points2[j] = (double)p;
+                 semiobjects[object_nr] = new CbcLotsize(cbcModel, i, len, points2, false);
+                 delete[] points2;
+              }
+              else
+#endif
+              {
+                 // lotsize for continuous variable or integer with large upper bounds
+                 //if( vartype == gmovar_SI )
+                 //   gevLogStat(gev, "Warning: Support of semiinteger variables with a range larger than 1000 is experimental.\n");
+                 points[2] = varlb;
+                 points[3] = varub;
+                 if( varlb == varub ) // var. can be only 0 or varlb
+                    semiobjects[object_nr] = new CbcLotsize(cbcModel.get(), i, 2, points+1, false);
+                 else // var. can be 0 or in the range between low and upper
+                    semiobjects[object_nr] = new CbcLotsize(cbcModel.get(), i, 2, points,   true );
+              }
+
+              // set actual lower bound of variable in solver
+              cbcModel->solver()->setColLower(i, 0.0);
+
+              ++object_nr;
+           }
+           assert(object_nr == numberOfSemiVars);
+
+           cbcModel->addObjects(numberOfSemiVars, semiobjects);
+
+           for( int i = 0; i < numberOfSemiVars; ++i )
+              delete semiobjects[i];
+           delete[] semiobjects;
+        }
+
         CbcSolverUsefulData solverData;
         CbcMain0(*cbcModel, solverData);
 

--- a/src/MIPSolver/MIPSolverCbc.h
+++ b/src/MIPSolver/MIPSolverCbc.h
@@ -195,6 +195,7 @@ private:
     double timeLimit = 1e100;
     double cutOff;
     int numberOfThreads = 1;
+    int numberOfSemiVars = 0;
 
     std::vector<std::vector<std::pair<std::string, double>>> MIPStarts;
 

--- a/src/MIPSolver/MIPSolverCbc.h
+++ b/src/MIPSolver/MIPSolverCbc.h
@@ -55,7 +55,7 @@ public:
 
     void checkParameters() override;
 
-    bool addVariable(std::string name, E_VariableType type, double lowerBound, double upperBound) override;
+    bool addVariable(std::string name, E_VariableType type, double lowerBound, double upperBound, double semiBound) override;
 
     bool initializeObjective() override;
     bool addLinearTermToObjective(double coefficient, int variableIndex) override;
@@ -195,11 +195,11 @@ private:
     double timeLimit = 1e100;
     double cutOff;
     int numberOfThreads = 1;
-    int numberOfSemiVars = 0;
 
     std::vector<std::vector<std::pair<std::string, double>>> MIPStarts;
 
     std::vector<E_VariableType> variableTypes;
+    std::vector<std::pair<int, std::array<double, 4> > > lotsizes;
 };
 
 } // namespace SHOT

--- a/src/MIPSolver/MIPSolverCbc.h
+++ b/src/MIPSolver/MIPSolverCbc.h
@@ -55,7 +55,8 @@ public:
 
     void checkParameters() override;
 
-    bool addVariable(std::string name, E_VariableType type, double lowerBound, double upperBound, double semiBound) override;
+    bool addVariable(
+        std::string name, E_VariableType type, double lowerBound, double upperBound, double semiBound) override;
 
     bool initializeObjective() override;
     bool addLinearTermToObjective(double coefficient, int variableIndex) override;
@@ -196,10 +197,10 @@ private:
     double cutOff;
     int numberOfThreads = 1;
 
-    std::vector<std::vector<std::pair<std::string, double>>> MIPStarts;
+    std::vector<std::pair<std::string, double>> MIPStart;
 
     std::vector<E_VariableType> variableTypes;
-    std::vector<std::pair<int, std::array<double, 4> > > lotsizes;
+    std::vector<std::pair<int, std::array<double, 4>>> lotsizes;
 };
 
 } // namespace SHOT

--- a/src/MIPSolver/MIPSolverCplex.cpp
+++ b/src/MIPSolver/MIPSolverCplex.cpp
@@ -614,9 +614,12 @@ bool MIPSolverCplex::addSpecialOrderedSet(E_SOSType type, VectorInteger variable
 
 void MIPSolverCplex::activateDiscreteVariables(bool activate)
 {
+    if(env->reformulatedProblem->properties.numberOfSemiintegerVariables > 0
+        || env->reformulatedProblem->properties.numberOfSemicontinuousVariables > 0)
+        return;
+
     try
     {
-
         for(auto& C : cplexVarConvers)
         {
             C.end();
@@ -630,7 +633,7 @@ void MIPSolverCplex::activateDiscreteVariables(bool activate)
 
             for(int i = 0; i < numberOfVariables; i++)
             {
-                if(variableTypes.at(i) == E_VariableType::Integer || variableTypes.at(i) == E_VariableType::Semiinteger)
+                if(variableTypes.at(i) == E_VariableType::Integer)
                 {
                     auto tmpVar = cplexVars[i];
                     auto tmpConv = IloConversion(cplexEnv, tmpVar, ILOINT);
@@ -653,8 +656,7 @@ void MIPSolverCplex::activateDiscreteVariables(bool activate)
             env->output->outputDebug("        Activating LP strategy.");
             for(int i = 0; i < numberOfVariables; i++)
             {
-                if(variableTypes.at(i) == E_VariableType::Integer || variableTypes.at(i) == E_VariableType::Binary
-                    || variableTypes.at(i) == E_VariableType::Semiinteger)
+                if(variableTypes.at(i) == E_VariableType::Integer || variableTypes.at(i) == E_VariableType::Binary)
                 {
                     auto tmpVar = cplexVars[i];
                     auto tmpConv = IloConversion(cplexEnv, tmpVar, ILOFLOAT);

--- a/src/MIPSolver/MIPSolverCplex.cpp
+++ b/src/MIPSolver/MIPSolverCplex.cpp
@@ -118,7 +118,7 @@ bool MIPSolverCplex::initializeProblem()
     return (true);
 }
 
-bool MIPSolverCplex::addVariable(std::string name, E_VariableType type, double lowerBound, double upperBound)
+bool MIPSolverCplex::addVariable(std::string name, E_VariableType type, double lowerBound, double upperBound, double semiBound)
 {
     if(lowerBound < -getUnboundedVariableBoundValue())
         lowerBound = -getUnboundedVariableBoundValue();
@@ -149,6 +149,10 @@ bool MIPSolverCplex::addVariable(std::string name, E_VariableType type, double l
         case E_VariableType::Semicontinuous:
         {
             isProblemDiscrete = true;
+            if( semiBound < 0.0 )
+                upperBound = semiBound;
+            else
+                lowerBound = semiBound;
             auto cplexVar = IloSemiContVar(cplexEnv, lowerBound, upperBound, ILOFLOAT, name.c_str());
             cplexVars.add(cplexVar);
             cplexModel.add(cplexVar);

--- a/src/MIPSolver/MIPSolverCplex.cpp
+++ b/src/MIPSolver/MIPSolverCplex.cpp
@@ -147,13 +147,14 @@ bool MIPSolverCplex::addVariable(std::string name, E_VariableType type, double l
             break;
         }
         case E_VariableType::Semicontinuous:
+        case E_VariableType::Semiinteger:
         {
             isProblemDiscrete = true;
             if( semiBound < 0.0 )
                 upperBound = semiBound;
             else
                 lowerBound = semiBound;
-            auto cplexVar = IloSemiContVar(cplexEnv, lowerBound, upperBound, ILOFLOAT, name.c_str());
+            auto cplexVar = IloSemiContVar(cplexEnv, lowerBound, upperBound, (type == E_VariableType::Semicontinuous) ? ILOFLOAT : ILOINT, name.c_str());
             cplexVars.add(cplexVar);
             cplexModel.add(cplexVar);
             break;

--- a/src/MIPSolver/MIPSolverCplex.cpp
+++ b/src/MIPSolver/MIPSolverCplex.cpp
@@ -1244,23 +1244,17 @@ void MIPSolverCplex::addMIPStart(VectorDouble point)
 {
     IloNumArray startVal(cplexEnv);
 
-    for(double P : point)
-    {
-        startVal.add(P);
-    }
+    if(point.size() < env->reformulatedProblem->properties.numberOfVariables)
+        env->reformulatedProblem->augmentAuxiliaryVariableValues(point);
 
-    for(auto& V : env->reformulatedProblem->auxiliaryVariables)
-    {
-        startVal.add(V->calculate(point));
-    }
+    assert(env->reformulatedProblem->properties.numberOfVariables == point.size());
+    assert(variableNames.size() == point.size());
 
-    if(env->reformulatedProblem->auxiliaryObjectiveVariable)
-        startVal.add(env->reformulatedProblem->auxiliaryObjectiveVariable->calculate(point));
-    else if(this->hasDualAuxiliaryObjectiveVariable())
+    if(this->hasDualAuxiliaryObjectiveVariable())
         startVal.add(env->reformulatedProblem->objectiveFunction->calculateValue(point));
 
-    while(startVal.getSize() < cplexVars.getSize())
-        startVal.add(0);
+    for(double P : point)
+        startVal.add(P);
 
     try
     {

--- a/src/MIPSolver/MIPSolverCplex.cpp
+++ b/src/MIPSolver/MIPSolverCplex.cpp
@@ -628,7 +628,7 @@ void MIPSolverCplex::activateDiscreteVariables(bool activate)
 
             for(int i = 0; i < numberOfVariables; i++)
             {
-                if(variableTypes.at(i) == E_VariableType::Integer)
+                if(variableTypes.at(i) == E_VariableType::Integer /*|| variableTypes.at(i) == E_VariableType::Semiinteger*/)
                 {
                     auto tmpVar = cplexVars[i];
                     auto tmpConv = IloConversion(cplexEnv, tmpVar, ILOINT);
@@ -651,7 +651,7 @@ void MIPSolverCplex::activateDiscreteVariables(bool activate)
             env->output->outputDebug("        Activating LP strategy.");
             for(int i = 0; i < numberOfVariables; i++)
             {
-                if(variableTypes.at(i) == E_VariableType::Integer || variableTypes.at(i) == E_VariableType::Binary)
+                if(variableTypes.at(i) == E_VariableType::Integer || variableTypes.at(i) == E_VariableType::Binary /*|| variableTypes.at(i) == E_VariableType::Semiinteger*/)
                 {
                     auto tmpVar = cplexVars[i];
                     auto tmpConv = IloConversion(cplexEnv, tmpVar, ILOFLOAT);
@@ -1588,7 +1588,7 @@ bool MIPSolverCplex::createIntegerCut(IntegerCut& integerCut)
             int variableValue = integerCut.variableValues[index];
             auto variable = cplexVars[VAR->index];
 
-            assert(VAR->properties.type == E_VariableType::Binary || VAR->properties.type == E_VariableType::Integer);
+            assert(VAR->properties.type == E_VariableType::Binary || VAR->properties.type == E_VariableType::Integer || VAR->properties.type == E_VariableType::Semiinteger);
 
             if(variableValue == VAR->upperBound)
             {

--- a/src/MIPSolver/MIPSolverCplex.cpp
+++ b/src/MIPSolver/MIPSolverCplex.cpp
@@ -118,7 +118,8 @@ bool MIPSolverCplex::initializeProblem()
     return (true);
 }
 
-bool MIPSolverCplex::addVariable(std::string name, E_VariableType type, double lowerBound, double upperBound, double semiBound)
+bool MIPSolverCplex::addVariable(
+    std::string name, E_VariableType type, double lowerBound, double upperBound, double semiBound)
 {
     if(lowerBound < -getUnboundedVariableBoundValue())
         lowerBound = -getUnboundedVariableBoundValue();
@@ -150,11 +151,12 @@ bool MIPSolverCplex::addVariable(std::string name, E_VariableType type, double l
         case E_VariableType::Semiinteger:
         {
             isProblemDiscrete = true;
-            if( semiBound < 0.0 )
+            if(semiBound < 0.0)
                 upperBound = semiBound;
             else
                 lowerBound = semiBound;
-            auto cplexVar = IloSemiContVar(cplexEnv, lowerBound, upperBound, (type == E_VariableType::Semicontinuous) ? ILOFLOAT : ILOINT, name.c_str());
+            auto cplexVar = IloSemiContVar(cplexEnv, lowerBound, upperBound,
+                (type == E_VariableType::Semicontinuous) ? ILOFLOAT : ILOINT, name.c_str());
             cplexVars.add(cplexVar);
             cplexModel.add(cplexVar);
             break;
@@ -628,7 +630,7 @@ void MIPSolverCplex::activateDiscreteVariables(bool activate)
 
             for(int i = 0; i < numberOfVariables; i++)
             {
-                if(variableTypes.at(i) == E_VariableType::Integer /*|| variableTypes.at(i) == E_VariableType::Semiinteger*/)
+                if(variableTypes.at(i) == E_VariableType::Integer || variableTypes.at(i) == E_VariableType::Semiinteger)
                 {
                     auto tmpVar = cplexVars[i];
                     auto tmpConv = IloConversion(cplexEnv, tmpVar, ILOINT);
@@ -651,7 +653,8 @@ void MIPSolverCplex::activateDiscreteVariables(bool activate)
             env->output->outputDebug("        Activating LP strategy.");
             for(int i = 0; i < numberOfVariables; i++)
             {
-                if(variableTypes.at(i) == E_VariableType::Integer || variableTypes.at(i) == E_VariableType::Binary /*|| variableTypes.at(i) == E_VariableType::Semiinteger*/)
+                if(variableTypes.at(i) == E_VariableType::Integer || variableTypes.at(i) == E_VariableType::Binary
+                    || variableTypes.at(i) == E_VariableType::Semiinteger)
                 {
                     auto tmpVar = cplexVars[i];
                     auto tmpConv = IloConversion(cplexEnv, tmpVar, ILOFLOAT);
@@ -1588,7 +1591,8 @@ bool MIPSolverCplex::createIntegerCut(IntegerCut& integerCut)
             int variableValue = integerCut.variableValues[index];
             auto variable = cplexVars[VAR->index];
 
-            assert(VAR->properties.type == E_VariableType::Binary || VAR->properties.type == E_VariableType::Integer || VAR->properties.type == E_VariableType::Semiinteger);
+            assert(VAR->properties.type == E_VariableType::Binary || VAR->properties.type == E_VariableType::Integer
+                || VAR->properties.type == E_VariableType::Semiinteger);
 
             if(variableValue == VAR->upperBound)
             {

--- a/src/MIPSolver/MIPSolverCplex.h
+++ b/src/MIPSolver/MIPSolverCplex.h
@@ -48,7 +48,7 @@ public:
 
     void checkParameters() override;
 
-    bool addVariable(std::string name, E_VariableType type, double lowerBound, double upperBound) override;
+    bool addVariable(std::string name, E_VariableType type, double lowerBound, double upperBound, double semiBound) override;
 
     bool initializeObjective() override;
     bool addLinearTermToObjective(double coefficient, int variableIndex) override;

--- a/src/MIPSolver/MIPSolverCplexSingleTree.cpp
+++ b/src/MIPSolver/MIPSolverCplexSingleTree.cpp
@@ -363,23 +363,16 @@ void CplexCallback::invoke(const IloCplex::Callback::Context& context)
 
             IloNumArray tmpVals(context.getEnv());
 
+            if(primalSol.size() < env->reformulatedProblem->properties.numberOfVariables)
+                env->reformulatedProblem->augmentAuxiliaryVariableValues(primalSol);
+
+            if(env->dualSolver->MIPSolver->hasDualAuxiliaryObjectiveVariable())
+                primalSol.push_back(env->reformulatedProblem->objectiveFunction->calculateValue(primalSol));
+
+            assert(cplexVars.getSize() == primalSol.size());
+
             for(double S : primalSol)
-            {
                 tmpVals.add(S);
-            }
-
-            for(auto& V : env->reformulatedProblem->auxiliaryVariables)
-            {
-                tmpVals.add(V->calculate(primalSol));
-            }
-
-            if(env->reformulatedProblem->auxiliaryObjectiveVariable)
-                tmpVals.add(env->reformulatedProblem->auxiliaryObjectiveVariable->calculate(primalSol));
-            else if(env->dualSolver->MIPSolver->hasDualAuxiliaryObjectiveVariable())
-                tmpVals.add(env->reformulatedProblem->objectiveFunction->calculateValue(primalSol));
-
-            while(tmpVals.getSize() < cplexVars.getSize())
-                tmpVals.add(0);
 
             try
             {
@@ -497,7 +490,8 @@ bool CplexCallback::createIntegerCut(IntegerCut& integerCut, const IloCplex::Cal
 
         for(auto& VAR : env->reformulatedProblem->allVariables)
         {
-            if(!(VAR->properties.type == E_VariableType::Binary || VAR->properties.type == E_VariableType::Integer || VAR->properties.type == E_VariableType::Semiinteger))
+            if(!(VAR->properties.type == E_VariableType::Binary || VAR->properties.type == E_VariableType::Integer
+                   || VAR->properties.type == E_VariableType::Semiinteger))
                 continue;
 
             int variableValue = integerCut.variableValues[index];

--- a/src/MIPSolver/MIPSolverCplexSingleTree.cpp
+++ b/src/MIPSolver/MIPSolverCplexSingleTree.cpp
@@ -497,7 +497,7 @@ bool CplexCallback::createIntegerCut(IntegerCut& integerCut, const IloCplex::Cal
 
         for(auto& VAR : env->reformulatedProblem->allVariables)
         {
-            if(!(VAR->properties.type == E_VariableType::Binary || VAR->properties.type == E_VariableType::Integer))
+            if(!(VAR->properties.type == E_VariableType::Binary || VAR->properties.type == E_VariableType::Integer || VAR->properties.type == E_VariableType::Semiinteger))
                 continue;
 
             int variableValue = integerCut.variableValues[index];

--- a/src/MIPSolver/MIPSolverCplexSingleTreeLegacy.cpp
+++ b/src/MIPSolver/MIPSolverCplexSingleTreeLegacy.cpp
@@ -70,23 +70,21 @@ void HCallbackI::main() // Called at each node...
 
         IloNumArray tmpVals(this->getEnv());
 
-        for(double S : primalSol)
-        {
-            tmpVals.add(S);
-        }
+        if(primalSol.size() < env->reformulatedProblem->properties.numberOfVariables)
+            env->reformulatedProblem->augmentAuxiliaryVariableValues(primalSol);
+
+        assert(env->reformulatedProblem->properties.numberOfVariables == primalSol.size());
+
+        if(env->dualSolver->MIPSolver->hasDualAuxiliaryObjectiveVariable())
+            primalSol.push_back(env->reformulatedProblem->objectiveFunction->calculateValue(primalSol));
+
+        for(double P : primalSol)
+            tmpVals.add(P);
 
         for(auto& V : env->reformulatedProblem->auxiliaryVariables)
         {
             tmpVals.add(V->calculate(primalSol));
         }
-
-        if(env->reformulatedProblem->auxiliaryObjectiveVariable)
-            tmpVals.add(env->reformulatedProblem->auxiliaryObjectiveVariable->calculate(primalSol));
-        else if(env->dualSolver->MIPSolver->hasDualAuxiliaryObjectiveVariable())
-            tmpVals.add(env->reformulatedProblem->objectiveFunction->calculateValue(primalSol));
-
-        while(tmpVals.getSize() < cplexVars.getSize())
-            tmpVals.add(0);
 
         try
         {
@@ -617,7 +615,8 @@ bool CtCallbackI::createIntegerCut(IntegerCut& integerCut)
 
         for(auto& VAR : env->reformulatedProblem->allVariables)
         {
-            if(!(VAR->properties.type == E_VariableType::Binary || VAR->properties.type == E_VariableType::Integer || VAR->properties.type == E_VariableType::Semiinteger))
+            if(!(VAR->properties.type == E_VariableType::Binary || VAR->properties.type == E_VariableType::Integer
+                   || VAR->properties.type == E_VariableType::Semiinteger))
                 continue;
 
             int variableValue = integerCut.variableValues[index];

--- a/src/MIPSolver/MIPSolverCplexSingleTreeLegacy.cpp
+++ b/src/MIPSolver/MIPSolverCplexSingleTreeLegacy.cpp
@@ -617,7 +617,7 @@ bool CtCallbackI::createIntegerCut(IntegerCut& integerCut)
 
         for(auto& VAR : env->reformulatedProblem->allVariables)
         {
-            if(!(VAR->properties.type == E_VariableType::Binary || VAR->properties.type == E_VariableType::Integer))
+            if(!(VAR->properties.type == E_VariableType::Binary || VAR->properties.type == E_VariableType::Integer || VAR->properties.type == E_VariableType::Semiinteger))
                 continue;
 
             int variableValue = integerCut.variableValues[index];

--- a/src/MIPSolver/MIPSolverGurobi.cpp
+++ b/src/MIPSolver/MIPSolverGurobi.cpp
@@ -1184,20 +1184,17 @@ void MIPSolverGurobi::addMIPStart(VectorDouble point)
     {
         VectorDouble startVal;
 
+        if(point.size() < env->reformulatedProblem->properties.numberOfVariables)
+            env->reformulatedProblem->augmentAuxiliaryVariableValues(point);
+
+        assert(env->reformulatedProblem->properties.numberOfVariables == point.size());
+        assert(variableNames.size() == point.size());
+
+        if(this->hasDualAuxiliaryObjectiveVariable())
+            point.push_back(env->reformulatedProblem->objectiveFunction->calculateValue(point));
+
         for(double P : point)
-        {
             startVal.push_back(P);
-        }
-
-        for(auto& V : env->reformulatedProblem->auxiliaryVariables)
-        {
-            startVal.push_back(V->calculate(point));
-        }
-
-        if(env->reformulatedProblem->auxiliaryObjectiveVariable)
-            startVal.push_back(env->reformulatedProblem->auxiliaryObjectiveVariable->calculate(point));
-        else if(this->hasDualAuxiliaryObjectiveVariable())
-            startVal.push_back(env->reformulatedProblem->objectiveFunction->calculateValue(point));
 
         for(size_t i = 0; i < startVal.size(); i++)
         {

--- a/src/MIPSolver/MIPSolverGurobi.cpp
+++ b/src/MIPSolver/MIPSolverGurobi.cpp
@@ -551,7 +551,7 @@ bool MIPSolverGurobi::createIntegerCut(IntegerCut& integerCut)
             int variableValue = integerCut.variableValues[index];
             auto variable = gurobiModel->getVar(I);
 
-            assert(VAR->properties.type == E_VariableType::Binary || VAR->properties.type == E_VariableType::Integer);
+            assert(VAR->properties.type == E_VariableType::Binary || VAR->properties.type == E_VariableType::Integer || VAR->properties.type == E_VariableType::Semiinteger);
 
             if(variableValue == VAR->upperBound)
             {

--- a/src/MIPSolver/MIPSolverGurobi.cpp
+++ b/src/MIPSolver/MIPSolverGurobi.cpp
@@ -76,7 +76,8 @@ bool MIPSolverGurobi::initializeProblem()
     return (true);
 }
 
-bool MIPSolverGurobi::addVariable(std::string name, E_VariableType type, double lowerBound, double upperBound, double semiBound)
+bool MIPSolverGurobi::addVariable(
+    std::string name, E_VariableType type, double lowerBound, double upperBound, double semiBound)
 {
     if(lowerBound < -getUnboundedVariableBoundValue())
         lowerBound = -getUnboundedVariableBoundValue();
@@ -104,7 +105,7 @@ bool MIPSolverGurobi::addVariable(std::string name, E_VariableType type, double 
 
         case E_VariableType::Semicontinuous:
             isProblemDiscrete = true;
-            if( semiBound < 0.0 )
+            if(semiBound < 0.0)
                 upperBound = semiBound;
             else
                 lowerBound = semiBound;
@@ -113,7 +114,7 @@ bool MIPSolverGurobi::addVariable(std::string name, E_VariableType type, double 
 
         case E_VariableType::Semiinteger:
             isProblemDiscrete = true;
-            if( semiBound < 0.0 )
+            if(semiBound < 0.0)
                 upperBound = semiBound;
             else
                 lowerBound = semiBound;
@@ -551,7 +552,8 @@ bool MIPSolverGurobi::createIntegerCut(IntegerCut& integerCut)
             int variableValue = integerCut.variableValues[index];
             auto variable = gurobiModel->getVar(I);
 
-            assert(VAR->properties.type == E_VariableType::Binary || VAR->properties.type == E_VariableType::Integer || VAR->properties.type == E_VariableType::Semiinteger);
+            assert(VAR->properties.type == E_VariableType::Binary || VAR->properties.type == E_VariableType::Integer
+                || VAR->properties.type == E_VariableType::Semiinteger);
 
             if(variableValue == VAR->upperBound)
             {
@@ -701,12 +703,20 @@ int MIPSolverGurobi::getNumberOfSolutions()
 
 void MIPSolverGurobi::activateDiscreteVariables(bool activate)
 {
+
+    if(env->reformulatedProblem->properties.numberOfSemiintegerVariables > 0
+        || env->reformulatedProblem->properties.numberOfSemicontinuousVariables > 0)
+        return;
+
     if(activate)
     {
         env->output->outputDebug("        Activating MIP strategy.");
 
         for(int i = 0; i < numberOfVariables; i++)
         {
+            assert(variableTypes.at(i) != E_VariableType::Semicontinuous
+                && variableTypes.at(i) != E_VariableType::Semiinteger);
+
             if(variableTypes.at(i) == E_VariableType::Integer)
             {
                 GRBVar tmpVar = gurobiModel->getVar(i);
@@ -725,8 +735,12 @@ void MIPSolverGurobi::activateDiscreteVariables(bool activate)
     else
     {
         env->output->outputDebug("        Activating LP strategy.");
+
         for(int i = 0; i < numberOfVariables; i++)
         {
+            assert(variableTypes.at(i) != E_VariableType::Semicontinuous
+                && variableTypes.at(i) != E_VariableType::Semiinteger);
+
             if(variableTypes.at(i) == E_VariableType::Integer || variableTypes.at(i) == E_VariableType::Binary)
             {
                 GRBVar tmpVar = gurobiModel->getVar(i);

--- a/src/MIPSolver/MIPSolverGurobi.cpp
+++ b/src/MIPSolver/MIPSolverGurobi.cpp
@@ -76,7 +76,7 @@ bool MIPSolverGurobi::initializeProblem()
     return (true);
 }
 
-bool MIPSolverGurobi::addVariable(std::string name, E_VariableType type, double lowerBound, double upperBound)
+bool MIPSolverGurobi::addVariable(std::string name, E_VariableType type, double lowerBound, double upperBound, double semiBound)
 {
     if(lowerBound < -getUnboundedVariableBoundValue())
         lowerBound = -getUnboundedVariableBoundValue();
@@ -104,6 +104,10 @@ bool MIPSolverGurobi::addVariable(std::string name, E_VariableType type, double 
 
         case E_VariableType::Semicontinuous:
             isProblemDiscrete = true;
+            if( semiBound < 0.0 )
+                upperBound = semiBound;
+            else
+                lowerBound = semiBound;
             gurobiModel->addVar(lowerBound, upperBound, 0.0, GRB_SEMICONT, name);
             break;
 

--- a/src/MIPSolver/MIPSolverGurobi.cpp
+++ b/src/MIPSolver/MIPSolverGurobi.cpp
@@ -111,6 +111,15 @@ bool MIPSolverGurobi::addVariable(std::string name, E_VariableType type, double 
             gurobiModel->addVar(lowerBound, upperBound, 0.0, GRB_SEMICONT, name);
             break;
 
+        case E_VariableType::Semiinteger:
+            isProblemDiscrete = true;
+            if( semiBound < 0.0 )
+                upperBound = semiBound;
+            else
+                lowerBound = semiBound;
+            gurobiModel->addVar(lowerBound, upperBound, 0.0, GRB_SEMIINT, name);
+            break;
+
         default:
             break;
         }

--- a/src/MIPSolver/MIPSolverGurobi.h
+++ b/src/MIPSolver/MIPSolverGurobi.h
@@ -28,7 +28,7 @@ public:
 
     void checkParameters() override;
 
-    bool addVariable(std::string name, E_VariableType type, double lowerBound, double upperBound) override;
+    bool addVariable(std::string name, E_VariableType type, double lowerBound, double upperBound, double semiBound) override;
 
     bool initializeObjective() override;
     bool addLinearTermToObjective(double coefficient, int variableIndex) override;

--- a/src/MIPSolver/MIPSolverGurobiSingleTree.cpp
+++ b/src/MIPSolver/MIPSolverGurobiSingleTree.cpp
@@ -452,23 +452,18 @@ void GurobiCallbackSingleTree::callback()
         {
             auto primalSol = env->results->primalSolution;
 
+            if(primalSol.size() < env->reformulatedProblem->properties.numberOfVariables)
+                env->reformulatedProblem->augmentAuxiliaryVariableValues(primalSol);
+
+            assert(env->reformulatedProblem->properties.numberOfVariables == primalSol.size());
+
+            if(env->dualSolver->MIPSolver->hasDualAuxiliaryObjectiveVariable())
+                primalSol.push_back(env->reformulatedProblem->objectiveFunction->calculateValue(primalSol));
+
             for(size_t i = 0; i < primalSol.size(); i++)
             {
                 setSolution(vars[i], primalSol.at(i));
             }
-
-            for(size_t i = 0; i < env->reformulatedProblem->auxiliaryVariables.size(); i++)
-            {
-                setSolution(vars[i + primalSol.size()],
-                    env->reformulatedProblem->auxiliaryVariables.at(i)->calculate(primalSol));
-            }
-
-            if(env->reformulatedProblem->auxiliaryObjectiveVariable)
-                setSolution(vars[env->reformulatedProblem->auxiliaryVariables.size() + primalSol.size()],
-                    env->reformulatedProblem->auxiliaryObjectiveVariable->calculate(primalSol));
-            else if(env->dualSolver->MIPSolver->hasDualAuxiliaryObjectiveVariable())
-                setSolution(vars[env->reformulatedProblem->auxiliaryVariables.size() + primalSol.size()],
-                    env->reformulatedProblem->objectiveFunction->calculateValue(primalSol));
 
             lastUpdatedPrimal = env->results->getPrimalBound();
         }
@@ -618,7 +613,8 @@ bool GurobiCallbackSingleTree::createIntegerCut(IntegerCut& integerCut)
 
         for(auto& VAR : env->reformulatedProblem->allVariables)
         {
-            if(!(VAR->properties.type == E_VariableType::Binary || VAR->properties.type == E_VariableType::Integer || VAR->properties.type == E_VariableType::Semiinteger))
+            if(!(VAR->properties.type == E_VariableType::Binary || VAR->properties.type == E_VariableType::Integer
+                   || VAR->properties.type == E_VariableType::Semiinteger))
                 continue;
 
             int variableValue = integerCut.variableValues[index];

--- a/src/MIPSolver/MIPSolverGurobiSingleTree.cpp
+++ b/src/MIPSolver/MIPSolverGurobiSingleTree.cpp
@@ -618,7 +618,7 @@ bool GurobiCallbackSingleTree::createIntegerCut(IntegerCut& integerCut)
 
         for(auto& VAR : env->reformulatedProblem->allVariables)
         {
-            if(!(VAR->properties.type == E_VariableType::Binary || VAR->properties.type == E_VariableType::Integer))
+            if(!(VAR->properties.type == E_VariableType::Binary || VAR->properties.type == E_VariableType::Integer || VAR->properties.type == E_VariableType::Semiinteger))
                 continue;
 
             int variableValue = integerCut.variableValues[index];

--- a/src/Model/AuxiliaryVariables.cpp
+++ b/src/Model/AuxiliaryVariables.cpp
@@ -64,7 +64,10 @@ std::ostream& operator<<(std::ostream& stream, AuxiliaryVariablePtr var)
         break;
 
     case E_VariableType::Semicontinuous:
-        stream << var->name << " in {0} or " << var->lowerBound << " <= " << var->name << " <= " << var->upperBound;
+        if( var->semiBound < 0.0 )
+            stream << var->name << " in {0} or " << var->lowerBound << " <= " << var->name << " <= " << var->semiBound;
+        else
+            stream << var->name << " in {0} or " << var->semiBound << " <= " << var->name << " <= " << var->upperBound;
         break;
 
     default:

--- a/src/Model/AuxiliaryVariables.cpp
+++ b/src/Model/AuxiliaryVariables.cpp
@@ -70,6 +70,13 @@ std::ostream& operator<<(std::ostream& stream, AuxiliaryVariablePtr var)
             stream << var->name << " in {0} or " << var->semiBound << " <= " << var->name << " <= " << var->upperBound;
         break;
 
+    case E_VariableType::Semiinteger:
+        if( var->semiBound < 0.0 )
+            stream << var->name << " in {" << var->lowerBound << ",...," << var->semiBound << ",0}";
+        else
+            stream << var->name << " in {0," << var->semiBound << ",...," << var->upperBound << "}";
+        break;
+
     default:
         stream << var->lowerBound << " <= " << var->name << " <= " << var->upperBound;
         break;

--- a/src/Model/AuxiliaryVariables.h
+++ b/src/Model/AuxiliaryVariables.h
@@ -37,10 +37,11 @@ public:
         properties.isAuxiliary = true;
     }
 
-    AuxiliaryVariable(std::string variableName, int variableIndex, E_VariableType variableType, double LB, double UB)
+    AuxiliaryVariable(std::string variableName, int variableIndex, E_VariableType variableType, double LB, double UB,
+        [[maybe_unused]] double variableSemiBound = NAN)
     {
-        assert(variableType != E_VariableType::Semicontinuous);  // not supported yet
-        assert(variableType != E_VariableType::Semiinteger);  // not supported yet
+        assert(variableType != E_VariableType::Semicontinuous); // not supported yet
+        assert(variableType != E_VariableType::Semiinteger); // not supported yet
         Variable::name = variableName;
         Variable::index = variableIndex;
         properties.type = variableType;
@@ -51,8 +52,8 @@ public:
 
     AuxiliaryVariable(std::string variableName, int variableIndex, E_VariableType variableType)
     {
-        assert(variableType != E_VariableType::Semicontinuous);  // not supported yet
-        assert(variableType != E_VariableType::Semiinteger);  // not supported yet
+        assert(variableType != E_VariableType::Semicontinuous); // not supported yet
+        assert(variableType != E_VariableType::Semiinteger); // not supported yet
         Variable::name = variableName;
         Variable::index = variableIndex;
         properties.type = variableType;

--- a/src/Model/AuxiliaryVariables.h
+++ b/src/Model/AuxiliaryVariables.h
@@ -40,6 +40,7 @@ public:
     AuxiliaryVariable(std::string variableName, int variableIndex, E_VariableType variableType, double LB, double UB)
     {
         assert(variableType != E_VariableType::Semicontinuous);  // not supported yet
+        assert(variableType != E_VariableType::Semiinteger);  // not supported yet
         Variable::name = variableName;
         Variable::index = variableIndex;
         properties.type = variableType;
@@ -51,6 +52,7 @@ public:
     AuxiliaryVariable(std::string variableName, int variableIndex, E_VariableType variableType)
     {
         assert(variableType != E_VariableType::Semicontinuous);  // not supported yet
+        assert(variableType != E_VariableType::Semiinteger);  // not supported yet
         Variable::name = variableName;
         Variable::index = variableIndex;
         properties.type = variableType;

--- a/src/Model/AuxiliaryVariables.h
+++ b/src/Model/AuxiliaryVariables.h
@@ -39,6 +39,7 @@ public:
 
     AuxiliaryVariable(std::string variableName, int variableIndex, E_VariableType variableType, double LB, double UB)
     {
+        assert(variableType != E_VariableType::Semicontinuous);  // not supported yet
         Variable::name = variableName;
         Variable::index = variableIndex;
         properties.type = variableType;
@@ -49,6 +50,7 @@ public:
 
     AuxiliaryVariable(std::string variableName, int variableIndex, E_VariableType variableType)
     {
+        assert(variableType != E_VariableType::Semicontinuous);  // not supported yet
         Variable::name = variableName;
         Variable::index = variableIndex;
         properties.type = variableType;

--- a/src/Model/Problem.cpp
+++ b/src/Model/Problem.cpp
@@ -581,9 +581,9 @@ void Problem::updateProperties()
     properties.numberOfRealVariables = realVariables.size();
     properties.numberOfBinaryVariables = binaryVariables.size();
     properties.numberOfIntegerVariables = integerVariables.size();
-    properties.numberOfDiscreteVariables = properties.numberOfBinaryVariables + properties.numberOfIntegerVariables;
     properties.numberOfSemicontinuousVariables = semicontinuousVariables.size();
     properties.numberOfSemiintegerVariables = semiintegerVariables.size();
+    properties.numberOfDiscreteVariables = properties.numberOfBinaryVariables + properties.numberOfIntegerVariables + properties.numberOfSemiintegerVariables;
     properties.numberOfNonlinearVariables = nonlinearVariables.size();
     properties.numberOfVariablesInNonlinearExpressions = nonlinearExpressionVariables.size();
     properties.numberOfAuxiliaryVariables = auxiliaryVariables.size();
@@ -593,7 +593,7 @@ void Problem::updateProperties()
 
     assert(properties.numberOfVariables
         == properties.numberOfRealVariables + properties.numberOfDiscreteVariables
-            + properties.numberOfSemicontinuousVariables + properties.numberOfSemiintegerVariables);
+            + properties.numberOfSemicontinuousVariables);
 
     properties.numberOfNumericConstraints = numericConstraints.size();
     properties.numberOfLinearConstraints = linearConstraints.size();
@@ -1648,6 +1648,12 @@ bool Problem::areNumericConstraintsFulfilled(VectorDouble point, double toleranc
 bool Problem::areIntegralityConstraintsFulfilled(VectorDouble point, double tolerance)
 {
     for(auto& V : integerVariables)
+    {
+        if(abs(point.at(V->index) - round(point.at(V->index))) > tolerance)
+            return false;
+    }
+
+    for(auto& V : semiintegerVariables)
     {
         if(abs(point.at(V->index) - round(point.at(V->index))) > tolerance)
             return false;

--- a/src/Model/Problem.cpp
+++ b/src/Model/Problem.cpp
@@ -2733,4 +2733,42 @@ ProblemPtr Problem::createCopy(
 
     return (destinationProblem);
 }
+
+void Problem::augmentAuxiliaryVariableValues(VectorDouble& point)
+{
+    auto originalLength = point.size();
+
+    if(!this->properties.isReformulated)
+        return;
+
+    assert(point.size() == this->properties.numberOfVariables - this->properties.numberOfAuxiliaryVariables);
+
+    for(auto& V : this->auxiliaryVariables)
+    {
+        double value = V->calculate(point);
+        point.push_back(value); // Need to add the values of the auxiliary variables in case these are needed by
+                                // subsequent aux. variables
+    }
+
+    if(this->auxiliaryObjectiveVariable)
+    {
+        double value = (this->objectiveFunction->properties.isMinimize)
+            ? this->auxiliaryObjectiveVariable->calculate(point)
+            : -1.0 * this->auxiliaryObjectiveVariable->calculate(point);
+
+        point.push_back(value);
+    }
+
+    if(this->antiEpigraphObjectiveVariable)
+        point.at(this->antiEpigraphObjectiveVariable->index) = this->objectiveFunction->calculateValue(point);
+
+    assert(point.size() == this->properties.numberOfVariables);
+
+    for(auto& PT : point)
+    {
+        assert(PT != NAN);
+    }
+
+    return;
+}
 } // namespace SHOT

--- a/src/Model/Problem.cpp
+++ b/src/Model/Problem.cpp
@@ -393,6 +393,7 @@ void Problem::updateVariables()
     binaryVariables.sortByIndex();
     integerVariables.sortByIndex();
     semicontinuousVariables.sortByIndex();
+    semiintegerVariables.sortByIndex();
     auxiliaryVariables.sortByIndex();
 
     nonlinearVariables.clear();
@@ -582,6 +583,7 @@ void Problem::updateProperties()
     properties.numberOfIntegerVariables = integerVariables.size();
     properties.numberOfDiscreteVariables = properties.numberOfBinaryVariables + properties.numberOfIntegerVariables;
     properties.numberOfSemicontinuousVariables = semicontinuousVariables.size();
+    properties.numberOfSemiintegerVariables = semiintegerVariables.size();
     properties.numberOfNonlinearVariables = nonlinearVariables.size();
     properties.numberOfVariablesInNonlinearExpressions = nonlinearExpressionVariables.size();
     properties.numberOfAuxiliaryVariables = auxiliaryVariables.size();
@@ -591,7 +593,7 @@ void Problem::updateProperties()
 
     assert(properties.numberOfVariables
         == properties.numberOfRealVariables + properties.numberOfDiscreteVariables
-            + properties.numberOfSemicontinuousVariables);
+            + properties.numberOfSemicontinuousVariables + properties.numberOfSemiintegerVariables);
 
     properties.numberOfNumericConstraints = numericConstraints.size();
     properties.numberOfLinearConstraints = linearConstraints.size();
@@ -655,7 +657,7 @@ void Problem::updateProperties()
     properties.numberOfSpecialOrderedSets = specialOrderedSets.size();
 
     properties.isDiscrete = (properties.numberOfDiscreteVariables > 0 || properties.numberOfSemicontinuousVariables > 0
-        || properties.numberOfSpecialOrderedSets > 0);
+        || properties.numberOfSpecialOrderedSets > 0 || properties.numberOfSemiintegerVariables > 0);
 
     if(areConstrsNonlinear || isObjNonlinear)
         properties.isNonlinear = true;
@@ -827,6 +829,7 @@ Problem::~Problem()
     binaryVariables.clear();
     integerVariables.clear();
     semicontinuousVariables.clear();
+    semiintegerVariables.clear();
     nonlinearVariables.clear();
     nonlinearExpressionVariables.clear();
 
@@ -881,6 +884,9 @@ void Problem::add(VariablePtr variable)
     case(E_VariableType::Semicontinuous):
         semicontinuousVariables.push_back(variable);
         break;
+    case(E_VariableType::Semiinteger):
+        semiintegerVariables.push_back(variable);
+        break;
     default:
         break;
     }
@@ -919,6 +925,9 @@ void Problem::add(AuxiliaryVariablePtr variable)
         break;
     case(E_VariableType::Semicontinuous):
         semicontinuousVariables.push_back(variable);
+        break;
+    case(E_VariableType::Semiinteger):
+        semiintegerVariables.push_back(variable);
         break;
     default:
         break;
@@ -2240,6 +2249,10 @@ bool Problem::verifyOwnership()
         return (false);
 
     if(std::any_of(semicontinuousVariables.begin(), semicontinuousVariables.end(),
+           [this](VariablePtr const& V) { return (V->ownerProblem.lock().get() != this); }))
+        return (false);
+
+    if(std::any_of(semiintegerVariables.begin(), semiintegerVariables.end(),
            [this](VariablePtr const& V) { return (V->ownerProblem.lock().get() != this); }))
         return (false);
 

--- a/src/Model/Problem.h
+++ b/src/Model/Problem.h
@@ -272,6 +272,8 @@ public:
     void doFBBT();
     bool doFBBTOnConstraint(NumericConstraintPtr constraint, double timeLimit);
 
+    void augmentAuxiliaryVariableValues(VectorDouble& point);
+
     friend std::ostream& operator<<(std::ostream& stream, const Problem& problem);
 
     ProblemPtr createCopy(EnvironmentPtr destinationEnv, bool integerRelaxed = false, bool convexityRelaxed = false,

--- a/src/Model/Problem.h
+++ b/src/Model/Problem.h
@@ -53,6 +53,7 @@ struct ProblemProperties
     int numberOfBinaryVariables = 0;
     int numberOfIntegerVariables = 0; // Not including binary variables
     int numberOfSemicontinuousVariables = 0;
+    int numberOfSemiintegerVariables = 0;
     int numberOfNonlinearVariables = 0;
     int numberOfVariablesInNonlinearExpressions = 0;
     int numberOfAuxiliaryVariables = 0;
@@ -134,6 +135,7 @@ public:
     Variables binaryVariables;
     Variables integerVariables;
     Variables semicontinuousVariables;
+    Variables semiintegerVariables;
     Variables nonlinearVariables; // All nonlinear variables, including in quadratic, signomial or monomial terms
     Variables nonlinearExpressionVariables; // Variables in general nonlinear expressions
 

--- a/src/Model/Problem.h
+++ b/src/Model/Problem.h
@@ -51,7 +51,7 @@ struct ProblemProperties
     int numberOfRealVariables = 0;
     int numberOfDiscreteVariables = 0; // Binary and integer variables
     int numberOfBinaryVariables = 0;
-    int numberOfIntegerVariables = 0; // Not including binary variables
+    int numberOfIntegerVariables = 0; // Not including binary or semiinteger variables
     int numberOfSemicontinuousVariables = 0;
     int numberOfSemiintegerVariables = 0;
     int numberOfNonlinearVariables = 0;

--- a/src/Model/Terms.h
+++ b/src/Model/Terms.h
@@ -335,6 +335,11 @@ public:
         {
             isInteger = true;
         }
+        else if(firstVariable->properties.type == E_VariableType::Semiinteger
+            && secondVariable->properties.type == E_VariableType::Semiinteger)
+        {
+            isInteger = true;
+        }
     };
 
     inline double calculate(const VectorDouble& point) const override

--- a/src/Model/Variables.cpp
+++ b/src/Model/Variables.cpp
@@ -44,7 +44,7 @@ bool Variable::tightenBounds(const Interval bound)
             // Special logic for negative zero
             this->lowerBound = -bound.l();
         }
-        else if(this->properties.type == E_VariableType::Binary || this->properties.type == E_VariableType::Integer)
+        else if(this->properties.type == E_VariableType::Binary || this->properties.type == E_VariableType::Integer || this->properties.type == E_VariableType::Semiinteger)
         {
             this->lowerBound = std::ceil(bound.l());
         }
@@ -64,7 +64,7 @@ bool Variable::tightenBounds(const Interval bound)
             // Special logic for negative zero
             this->upperBound = -bound.u();
         }
-        else if(this->properties.type == E_VariableType::Binary || this->properties.type == E_VariableType::Integer)
+        else if(this->properties.type == E_VariableType::Binary || this->properties.type == E_VariableType::Integer || this->properties.type == E_VariableType::Semiinteger)
         {
             this->upperBound = std::floor(bound.u());
         }

--- a/src/Model/Variables.cpp
+++ b/src/Model/Variables.cpp
@@ -44,7 +44,8 @@ bool Variable::tightenBounds(const Interval bound)
             // Special logic for negative zero
             this->lowerBound = -bound.l();
         }
-        else if(this->properties.type == E_VariableType::Binary || this->properties.type == E_VariableType::Integer || this->properties.type == E_VariableType::Semiinteger)
+        else if(this->properties.type == E_VariableType::Binary || this->properties.type == E_VariableType::Integer
+            || this->properties.type == E_VariableType::Semiinteger)
         {
             this->lowerBound = std::ceil(bound.l());
         }
@@ -64,7 +65,8 @@ bool Variable::tightenBounds(const Interval bound)
             // Special logic for negative zero
             this->upperBound = -bound.u();
         }
-        else if(this->properties.type == E_VariableType::Binary || this->properties.type == E_VariableType::Integer || this->properties.type == E_VariableType::Semiinteger)
+        else if(this->properties.type == E_VariableType::Binary || this->properties.type == E_VariableType::Integer
+            || this->properties.type == E_VariableType::Semiinteger)
         {
             this->upperBound = std::floor(bound.u());
         }
@@ -129,27 +131,27 @@ std::ostream& operator<<(std::ostream& stream, VariablePtr var)
     switch(var->properties.type)
     {
     case(E_VariableType::Real):
-        type << "C";
+        type << "C ";
         break;
 
     case(E_VariableType::Binary):
-        type << "B";
+        type << "B ";
         break;
 
     case(E_VariableType::Integer):
-        type << "I";
+        type << "I ";
         break;
 
     case(E_VariableType::Semicontinuous):
-        type << "C";
+        type << "SC";
         break;
 
     case(E_VariableType::Semiinteger):
-        type << "D";
+        type << "SI";
         break;
 
     default:
-        type << "?";
+        type << "? ";
         break;
     }
 
@@ -202,7 +204,7 @@ std::ostream& operator<<(std::ostream& stream, VariablePtr var)
     else
         inTerms << " ";
 
-    stream << fmt::format("[{:>5d},{:<1s}] [{:<4s}] [{:<5s}]\t{:>10}  {:1s} <= {:^14s}  <= {:1s} {:<10}", var->index,
+    stream << fmt::format("[{:>6d},{:<1s}] [{:<4s}] [{:<5s}]\t{:>10}  {:1s} <= {:^14s}  <= {:1s} {:<10}", var->index,
         type.str(), contains.str(), inTerms.str(), var->lowerBound,
         var->properties.hasLowerBoundBeenTightened ? "*" : " ", var->name,
         var->properties.hasUpperBoundBeenTightened ? "*" : " ", var->upperBound);

--- a/src/Model/Variables.cpp
+++ b/src/Model/Variables.cpp
@@ -144,6 +144,10 @@ std::ostream& operator<<(std::ostream& stream, VariablePtr var)
         type << "C";
         break;
 
+    case(E_VariableType::Semiinteger):
+        type << "D";
+        break;
+
     default:
         type << "?";
         break;

--- a/src/Model/Variables.cpp
+++ b/src/Model/Variables.cpp
@@ -205,7 +205,10 @@ std::ostream& operator<<(std::ostream& stream, VariablePtr var)
         inTerms << " ";
 
     stream << fmt::format("[{:>6d},{:<1s}] [{:<4s}] [{:<5s}]\t{:>10}  {:1s} <= {:^14s}  <= {:1s} {:<10}", var->index,
-        type.str(), contains.str(), inTerms.str(), var->lowerBound,
+        type.str(), contains.str(), inTerms.str(),
+        (var->properties.type == E_VariableType::Semicontinuous || var->properties.type == E_VariableType::Semiinteger)
+            ? var->semiBound
+            : var->lowerBound,
         var->properties.hasLowerBoundBeenTightened ? "*" : " ", var->name,
         var->properties.hasUpperBoundBeenTightened ? "*" : " ", var->upperBound);
 

--- a/src/Model/Variables.h
+++ b/src/Model/Variables.h
@@ -70,6 +70,7 @@ public:
 
     double upperBound;
     double lowerBound;
+    double semiBound;
 
     FactorableFunction* factorableFunctionVariable;
 
@@ -89,6 +90,28 @@ public:
         {
             lowerBound = 0;
             upperBound = 1;
+        }
+        else if(variableType == E_VariableType::Semicontinuous)
+        {
+            if( LB > 0.0 )
+            {
+                lowerBound = 0.0;
+                upperBound = UB;
+                semiBound = LB;
+            }
+            else if( UB < 0.0 )
+            {
+                lowerBound = LB;
+                upperBound = 0.0;
+                semiBound = UB;
+            }
+            else
+            {
+                // LB <= 0, UB >= 0 -> change to ordinary continuous variable
+                variableType = E_VariableType::Real;
+                lowerBound = LB;
+                upperBound = UB;
+            }
         }
         else
         {
@@ -113,6 +136,8 @@ public:
         {
             lowerBound = SHOT_DBL_MIN;
             upperBound = SHOT_DBL_MAX;
+            if(variableType == E_VariableType::Semicontinuous)
+                variableType = E_VariableType::Real;
         }
 
         properties.type = variableType;

--- a/src/Model/Variables.h
+++ b/src/Model/Variables.h
@@ -91,7 +91,7 @@ public:
             lowerBound = 0;
             upperBound = 1;
         }
-        else if(variableType == E_VariableType::Semicontinuous)
+        else if(variableType == E_VariableType::Semicontinuous || variableType == E_VariableType::Semiinteger)
         {
             if( LB > 0.0 )
             {
@@ -108,7 +108,7 @@ public:
             else
             {
                 // LB <= 0, UB >= 0 -> change to ordinary continuous variable
-                variableType = E_VariableType::Real;
+                variableType = (variableType == E_VariableType::Semicontinuous) ? E_VariableType::Real : E_VariableType::Integer;
                 lowerBound = LB;
                 upperBound = UB;
             }
@@ -138,6 +138,8 @@ public:
             upperBound = SHOT_DBL_MAX;
             if(variableType == E_VariableType::Semicontinuous)
                 variableType = E_VariableType::Real;
+            else if(variableType == E_VariableType::Semiinteger)
+                variableType = E_VariableType::Integer;
         }
 
         properties.type = variableType;

--- a/src/Model/Variables.h
+++ b/src/Model/Variables.h
@@ -81,7 +81,7 @@ public:
     }
 
     Variable(std::string variableName, int variableIndex, E_VariableType variableType, [[maybe_unused]] double LB,
-        [[maybe_unused]] double UB)
+        [[maybe_unused]] double UB, double variableSemiBound = NAN)
     {
         index = variableIndex;
         name = variableName;
@@ -91,28 +91,6 @@ public:
             lowerBound = 0;
             upperBound = 1;
         }
-        else if(variableType == E_VariableType::Semicontinuous || variableType == E_VariableType::Semiinteger)
-        {
-            if( LB > 0.0 )
-            {
-                lowerBound = 0.0;
-                upperBound = UB;
-                semiBound = LB;
-            }
-            else if( UB < 0.0 )
-            {
-                lowerBound = LB;
-                upperBound = 0.0;
-                semiBound = UB;
-            }
-            else
-            {
-                // LB <= 0, UB >= 0 -> change to ordinary continuous variable
-                variableType = (variableType == E_VariableType::Semicontinuous) ? E_VariableType::Real : E_VariableType::Integer;
-                lowerBound = LB;
-                upperBound = UB;
-            }
-        }
         else
         {
             lowerBound = LB;
@@ -120,6 +98,7 @@ public:
         }
 
         properties.type = variableType;
+        semiBound = variableSemiBound;
     };
 
     Variable(std::string variableName, int variableIndex, E_VariableType variableType)

--- a/src/ModelingSystem/ModelingSystemGAMS.cpp
+++ b/src/ModelingSystem/ModelingSystemGAMS.cpp
@@ -833,9 +833,9 @@ bool ModelingSystemGAMS::copyVariables(ProblemPtr destination)
             case gmovar_SC:
                 variableType = E_VariableType::Semicontinuous;
 
-                if(variableLBs[i] < 0.0)
+                if(variableLBs[i] < minLBCont)
                 {
-                    variableLBs[i] = 0.0;
+                    variableLBs[i] = minLBCont;
                 }
 
                 if(variableUBs[i] > maxUBCont)

--- a/src/ModelingSystem/ModelingSystemGAMS.cpp
+++ b/src/ModelingSystem/ModelingSystemGAMS.cpp
@@ -845,12 +845,18 @@ bool ModelingSystemGAMS::copyVariables(ProblemPtr destination)
 
                 break;
             case gmovar_SI:
-                env->output->outputError(" Unsupported variable type.");
+                variableType = E_VariableType::Semiinteger;
 
-                delete[] variableLBs;
-                delete[] variableUBs;
+                if(variableLBs[i] < minLBInt)
+                {
+                    variableLBs[i] = minLBInt;
+                }
 
-                return (false);
+                if(variableUBs[i] > maxUBInt)
+                {
+                    variableUBs[i] = maxUBInt;
+                }
+
                 break;
             default:
                 env->output->outputError(" Unsupported variable type.");

--- a/src/ModelingSystem/ModelingSystemOS.cpp
+++ b/src/ModelingSystem/ModelingSystemOS.cpp
@@ -280,6 +280,25 @@ bool ModelingSystemOS::copyVariables(OSInstance* source, ProblemPtr destination)
 
                 break;
 
+            case 'J':
+                variableType = E_VariableType::Semiinteger;
+
+                if(variableLB < minLBInt)
+                {
+                    // env->output->outputDebug("Corrected lower bound for variable " + variableNames[i] + " from " +
+                    // std::to_string(variableLBs[i]) + " to " + std::to_string(minLBInt));
+                    variableLB = minLBInt;
+                }
+
+                if(variableUB > maxUBInt)
+                {
+                    // env->output->outputDebug("Corrected upper bound for variable " + variableNames[i] + " from " +
+                    // std::to_string(variableUBs[i]) + " to " + std::to_string(maxUBInt));
+                    variableUB = maxUBInt;
+                }
+
+                break;
+
             default:
                 return (false);
                 break;

--- a/src/ModelingSystem/ModelingSystemOS.cpp
+++ b/src/ModelingSystem/ModelingSystemOS.cpp
@@ -264,11 +264,11 @@ bool ModelingSystemOS::copyVariables(OSInstance* source, ProblemPtr destination)
             case 'D':
                 variableType = E_VariableType::Semicontinuous;
 
-                if(variableLB < 0.0)
+                if(variableLB < minLBCont)
                 {
                     // env->output->outputDebug("Corrected lower bound for variable " + variableNames[i] + " from " +
-                    // std::to_string(variableLBs[i]) + " to " + std::to_string(0.0));
-                    variableLB = 0.0;
+                    // std::to_string(variableLBs[i]) + " to " + std::to_string(minLBCont));
+                    variableLB = minLBCont;
                 }
 
                 if(variableUB > maxUBCont)

--- a/src/ModelingSystem/ModelingSystemOSiL.cpp
+++ b/src/ModelingSystem/ModelingSystemOSiL.cpp
@@ -136,8 +136,8 @@ E_ProblemCreationStatus ModelingSystemOSiL::createProblem(ProblemPtr& problem, c
         case 'D':
             variableType = E_VariableType::Semicontinuous;
 
-            if(variableLB < 0.0)
-                variableLB = 0.0;
+            if(variableLB < minLBCont)
+                variableLB = minLBCont;
 
             if(variableUB > maxUBCont)
                 variableUB = maxUBCont;

--- a/src/ModelingSystem/ModelingSystemOSiL.cpp
+++ b/src/ModelingSystem/ModelingSystemOSiL.cpp
@@ -144,6 +144,17 @@ E_ProblemCreationStatus ModelingSystemOSiL::createProblem(ProblemPtr& problem, c
 
             break;
 
+        case 'J':
+            variableType = E_VariableType::Semiinteger;
+
+            if(variableLB < minLBInt)
+                variableLB = minLBInt;
+
+            if(variableUB > maxUBInt)
+                variableUB = maxUBInt;
+
+            break;
+
         default:
             return (E_ProblemCreationStatus::ErrorInVariables);
             break;

--- a/src/ModelingSystem/ModelingSystemOSiL.cpp
+++ b/src/ModelingSystem/ModelingSystemOSiL.cpp
@@ -184,7 +184,7 @@ E_ProblemCreationStatus ModelingSystemOSiL::createProblem(ProblemPtr& problem, c
             }
             else
             {
-                variableType = E_VariableType::Real;
+                variableType = E_VariableType::Integer;
             }
 
             break;

--- a/src/NLPSolver/NLPSolverCuttingPlaneMinimax.cpp
+++ b/src/NLPSolver/NLPSolverCuttingPlaneMinimax.cpp
@@ -400,7 +400,7 @@ bool NLPSolverCuttingPlaneMinimax::createProblem(IMIPSolver* destination, Proble
     for(auto& V : sourceProblem->allVariables)
     {
         variablesInitialized = variablesInitialized
-            && destination->addVariable(V->name, V->properties.type, V->lowerBound, V->upperBound);
+            && destination->addVariable(V->name, V->properties.type, V->lowerBound, V->upperBound, V->semiBound);
 
         if(env->settings->getSetting<bool>("Debug.Enable", "Output"))
         {
@@ -413,7 +413,7 @@ bool NLPSolverCuttingPlaneMinimax::createProblem(IMIPSolver* destination, Proble
     double objLowerBound = env->settings->getSetting<double>("ESH.InteriorPoint.MinimaxObjectiveLowerBound", "Dual");
 
     variablesInitialized = variablesInitialized
-        && destination->addVariable("shot_mmobjvar", E_VariableType::Real, objLowerBound, objUpperBound);
+        && destination->addVariable("shot_mmobjvar", E_VariableType::Real, objLowerBound, objUpperBound, 0.0);
 
     if(env->settings->getSetting<bool>("Debug.Enable", "Output"))
     {

--- a/src/NLPSolver/NLPSolverSHOT.cpp
+++ b/src/NLPSolver/NLPSolverSHOT.cpp
@@ -235,21 +235,10 @@ E_NLPSolutionStatus NLPSolverSHOT::solveProblemInstance()
             std::vector<double> tmpSolPt(
                 HP.generatedPoint.begin(), HP.generatedPoint.begin() + env->problem->properties.numberOfVariables);
 
-            for(auto& V : env->reformulatedProblem->auxiliaryVariables)
-            {
-                tmpSolPt.push_back(V->calculate(tmpSolPt));
-            }
+            if(tmpSolPt.size() < env->reformulatedProblem->properties.numberOfVariables)
+                env->reformulatedProblem->augmentAuxiliaryVariableValues(tmpSolPt);
 
-            if(env->reformulatedProblem->auxiliaryObjectiveVariable)
-            {
-                tmpSolPt.push_back(env->reformulatedProblem->auxiliaryObjectiveVariable->calculate(tmpSolPt));
-            }
-
-            if(env->reformulatedProblem->antiEpigraphObjectiveVariable)
-            {
-                tmpSolPt.at(env->reformulatedProblem->antiEpigraphObjectiveVariable->index)
-                    = env->reformulatedProblem->objectiveFunction->calculateValue(tmpSolPt);
-            }
+            assert(tmpSolPt.size() == env->reformulatedProblem->properties.numberOfVariables);
 
             Hyperplane hyperplane;
             hyperplane.generatedPoint = tmpSolPt;

--- a/src/PrimalSolver.cpp
+++ b/src/PrimalSolver.cpp
@@ -526,18 +526,8 @@ void PrimalSolver::addFixedNLPCandidate(
 {
     VectorDouble candidate(pt);
 
-    if((int)candidate.size() < env->reformulatedProblem->properties.numberOfVariables)
-    {
-        for(auto& V : env->reformulatedProblem->auxiliaryVariables)
-        {
-            candidate.push_back(V->calculate(pt));
-        }
-
-        if(env->reformulatedProblem->auxiliaryObjectiveVariable)
-        {
-            candidate.push_back(env->reformulatedProblem->auxiliaryObjectiveVariable->calculate(pt));
-        }
-    }
+    if(candidate.size() < env->reformulatedProblem->properties.numberOfVariables)
+        env->reformulatedProblem->augmentAuxiliaryVariableValues(candidate);
 
     assert((int)candidate.size() == env->reformulatedProblem->properties.numberOfVariables);
 

--- a/src/PrimalSolver.cpp
+++ b/src/PrimalSolver.cpp
@@ -190,6 +190,36 @@ bool PrimalSolver::checkPrimalSolutionPoint(PrimalSolution primalSol)
         }
     }
 
+    for(auto& V : env->problem->semiintegerVariables)
+    {
+        auto value = V->calculate(tmpPoint);
+
+        if(value != 0.0)
+        {
+            double lb, ub;
+            if( V->semiBound < 0.0 )
+            {
+                lb = V->lowerBound;
+                ub = V->semiBound;
+            }
+            else
+            {
+                lb = V->semiBound;
+                ub = V->upperBound;
+            }
+            if(value > ub)
+            {
+                isVariableBoundsFulfilled = false;
+                tmpPoint.at(V->index) = V->upperBound;
+            }
+            else if(value < lb)
+            {
+                isVariableBoundsFulfilled = false;
+                tmpPoint.at(V->index) = V->lowerBound;
+            }
+        }
+    }
+
     for(auto& V : env->problem->integerVariables)
     {
         auto value = V->calculate(tmpPoint);

--- a/src/PrimalSolver.cpp
+++ b/src/PrimalSolver.cpp
@@ -164,16 +164,29 @@ bool PrimalSolver::checkPrimalSolutionPoint(PrimalSolution primalSol)
     {
         auto value = V->calculate(tmpPoint);
 
-        if(value == 0.0) { }
-        else if(value > V->upperBound)
+        if(value != 0.0)
         {
-            isVariableBoundsFulfilled = false;
-            tmpPoint.at(V->index) = V->upperBound;
-        }
-        else if(value < V->lowerBound)
-        {
-            isVariableBoundsFulfilled = false;
-            tmpPoint.at(V->index) = V->lowerBound;
+            double lb, ub;
+            if( V->semiBound < 0.0 )
+            {
+                lb = V->lowerBound;
+                ub = V->semiBound;
+            }
+            else
+            {
+                lb = V->semiBound;
+                ub = V->upperBound;
+            }
+            if(value > ub)
+            {
+                isVariableBoundsFulfilled = false;
+                tmpPoint.at(V->index) = V->upperBound;
+            }
+            else if(value < lb)
+            {
+                isVariableBoundsFulfilled = false;
+                tmpPoint.at(V->index) = V->lowerBound;
+            }
         }
     }
 

--- a/src/Report.cpp
+++ b/src/Report.cpp
@@ -785,6 +785,12 @@ void Report::outputProblemInstanceReport()
                 " - semicontinuous:", env->problem->properties.numberOfSemicontinuousVariables,
                 env->reformulatedProblem->properties.numberOfSemicontinuousVariables));
 
+        if(env->problem->properties.numberOfSemiintegerVariables > 0
+            || env->reformulatedProblem->properties.numberOfSemiintegerVariables > 0)
+            env->output->outputInfo(fmt::format(" {:35s}{:<21d}{:d}",
+                " - semiinteger:", env->problem->properties.numberOfSemiintegerVariables,
+                env->reformulatedProblem->properties.numberOfSemiintegerVariables));
+
         if(env->problem->properties.numberOfNonlinearVariables > 0
             || env->reformulatedProblem->properties.numberOfNonlinearVariables > 0)
             env->output->outputInfo(
@@ -812,7 +818,11 @@ void Report::outputProblemInstanceReport()
         if(env->problem->properties.numberOfSemicontinuousVariables > 0)
             env->output->outputInfo(fmt::format(" {:35s}{:<21d}{:s}",
                 " - semicontinuous:", env->problem->properties.numberOfSemicontinuousVariables, ""));
-    }
+
+        if(env->problem->properties.numberOfSemiintegerVariables > 0)
+            env->output->outputInfo(fmt::format(" {:35s}{:<21d}{:s}",
+                " - semiinteger:", env->problem->properties.numberOfSemiintegerVariables, ""));
+}
 
     if(env->problem->properties.numberOfSpecialOrderedSets
             + env->reformulatedProblem->properties.numberOfSpecialOrderedSets

--- a/src/SolutionStrategy/SolutionStrategyMultiTree.cpp
+++ b/src/SolutionStrategy/SolutionStrategyMultiTree.cpp
@@ -119,7 +119,9 @@ SolutionStrategyMultiTree::SolutionStrategyMultiTree(EnvironmentPtr envPtr)
     auto tAddHPs = std::make_shared<TaskAddHyperplanes>(env);
     env->tasks->addTask(tAddHPs, "AddHPs");
 
-    if(env->settings->getSetting<bool>("Relaxation.Use", "Dual"))
+    if(env->settings->getSetting<bool>("Relaxation.Use", "Dual")
+        && env->reformulatedProblem->properties.numberOfSemicontinuousVariables == 0
+        && env->reformulatedProblem->properties.numberOfSemiintegerVariables == 0)
     {
         auto tExecuteRelaxStrategy = std::make_shared<TaskExecuteRelaxationStrategy>(env);
         env->tasks->addTask(tExecuteRelaxStrategy, "ExecRelaxStrategyInitial");
@@ -242,7 +244,9 @@ SolutionStrategyMultiTree::SolutionStrategyMultiTree(EnvironmentPtr envPtr)
         env->tasks->addTask(tCreateDualProblem, "CreateMILPProblem");
     }
 
-    if(env->settings->getSetting<bool>("Relaxation.Use", "Dual"))
+    if(env->settings->getSetting<bool>("Relaxation.Use", "Dual")
+        && env->reformulatedProblem->properties.numberOfSemicontinuousVariables == 0
+        && env->reformulatedProblem->properties.numberOfSemiintegerVariables == 0)
     {
         auto tExecuteRelaxStrategy = std::make_shared<TaskExecuteRelaxationStrategy>(env);
         env->tasks->addTask(tExecuteRelaxStrategy, "ExecRelaxStrategy");

--- a/src/SolutionStrategy/SolutionStrategySingleTree.cpp
+++ b/src/SolutionStrategy/SolutionStrategySingleTree.cpp
@@ -115,7 +115,9 @@ SolutionStrategySingleTree::SolutionStrategySingleTree(EnvironmentPtr envPtr)
     auto tAddHPs = std::make_shared<TaskAddHyperplanes>(env);
     env->tasks->addTask(tAddHPs, "AddHPs");
 
-    if(env->settings->getSetting<bool>("Relaxation.Use", "Dual"))
+    if(env->settings->getSetting<bool>("Relaxation.Use", "Dual")
+        && env->reformulatedProblem->properties.numberOfSemicontinuousVariables == 0
+        && env->reformulatedProblem->properties.numberOfSemiintegerVariables == 0)
     {
         auto tExecuteRelaxStrategy = std::make_shared<TaskExecuteRelaxationStrategy>(env);
         env->tasks->addTask(tExecuteRelaxStrategy, "ExecRelaxStrategyInitial");
@@ -227,7 +229,9 @@ SolutionStrategySingleTree::SolutionStrategySingleTree(EnvironmentPtr envPtr)
 
     env->tasks->addTask(tInitializeIteration, "InitIter2");
 
-    if(env->settings->getSetting<bool>("Relaxation.Use", "Dual"))
+    if(env->settings->getSetting<bool>("Relaxation.Use", "Dual")
+        && env->reformulatedProblem->properties.numberOfSemicontinuousVariables == 0
+        && env->reformulatedProblem->properties.numberOfSemiintegerVariables == 0)
     {
         auto tExecuteRelaxStrategy = std::make_shared<TaskExecuteRelaxationStrategy>(env);
         env->tasks->addTask(tExecuteRelaxStrategy, "ExecRelaxStrategy");

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -456,7 +456,8 @@ bool Solver::selectStrategy()
     {
         if(static_cast<ES_MIPSolver>(env->settings->getSetting<int>("MIP.Solver", "Dual")) == ES_MIPSolver::Cbc)
         {
-            if(env->problem->properties.numberOfDiscreteVariables == 0 && env->problem->properties.numberOfSemicontinuousVariables == 0)
+            if(env->problem->properties.numberOfDiscreteVariables == 0
+                && env->problem->properties.numberOfSemicontinuousVariables == 0)
             {
                 env->output->outputDebug(" Using continuous problem solution strategy.");
                 solutionStrategy = std::make_unique<SolutionStrategyNLP>(env);
@@ -1683,29 +1684,6 @@ void Solver::verifySettings()
     {
         MIPSolverDefined = true;
         unboundedVariableBound = 1e20;
-
-#if GRB_VERSION_MAJOR < 9
-        if(env->settings->getSetting<int>("Reformulation.Quadratics.ExtractStrategy", "Model")
-            > (int)ES_QuadraticTermsExtractStrategy::ExtractTermsToSame)
-            env->settings->updateSetting("Reformulation.Quadratics.ExtractStrategy", "Model",
-                (int)ES_QuadraticTermsExtractStrategy::ExtractTermsToSame);
-#endif
-
-#if GRB_VERSION_MAJOR >= 9
-
-        if(env->settings->getSetting<bool>("UseRecommendedSettings", "Strategy"))
-        {
-            // Activate Gurobi nonconvex MIQCQP solver for all nonconvex quadratic terms by default
-            env->settings->updateSetting("Reformulation.Quadratics.Strategy", "Model",
-                (int)ES_QuadraticProblemStrategy::NonconvexQuadraticallyConstrained);
-        }
-        else if(env->settings->getSetting<int>("Reformulation.Quadratics.ExtractStrategy", "Model")
-            > (int)ES_QuadraticTermsExtractStrategy::ExtractTermsToSame)
-        {
-            env->settings->updateSetting("Reformulation.Quadratics.Strategy", "Model",
-                (int)ES_QuadraticProblemStrategy::NonconvexQuadraticallyConstrained);
-        }
-#endif
     }
 #endif
 
@@ -1826,6 +1804,34 @@ void Solver::setConvexityBasedSettings()
                     env->settings->updateSetting("Cplex.OptimalityTarget", "Subsolver", 3);
             }
 
+#endif
+
+#ifdef HAS_GUROBI
+            if(static_cast<ES_MIPSolver>(env->settings->getSetting<int>("MIP.Solver", "Dual")) == ES_MIPSolver::Gurobi)
+            {
+#if GRB_VERSION_MAJOR < 9
+                if(env->settings->getSetting<int>("Reformulation.Quadratics.ExtractStrategy", "Model")
+                    > (int)ES_QuadraticTermsExtractStrategy::ExtractTermsToSame)
+                    env->settings->updateSetting("Reformulation.Quadratics.ExtractStrategy", "Model",
+                        (int)ES_QuadraticTermsExtractStrategy::ExtractTermsToSame);
+#endif
+
+#if GRB_VERSION_MAJOR >= 9
+
+                if(env->settings->getSetting<bool>("UseRecommendedSettings", "Strategy"))
+                {
+                    // Activate Gurobi nonconvex MIQCQP solver for all nonconvex quadratic terms by default
+                    env->settings->updateSetting("Reformulation.Quadratics.Strategy", "Model",
+                        (int)ES_QuadraticProblemStrategy::NonconvexQuadraticallyConstrained);
+                }
+                else if(env->settings->getSetting<int>("Reformulation.Quadratics.ExtractStrategy", "Model")
+                    > (int)ES_QuadraticTermsExtractStrategy::ExtractTermsToSame)
+                {
+                    env->settings->updateSetting("Reformulation.Quadratics.Strategy", "Model",
+                        (int)ES_QuadraticProblemStrategy::NonconvexQuadraticallyConstrained);
+                }
+#endif
+            }
 #endif
         }
 

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -456,7 +456,7 @@ bool Solver::selectStrategy()
     {
         if(static_cast<ES_MIPSolver>(env->settings->getSetting<int>("MIP.Solver", "Dual")) == ES_MIPSolver::Cbc)
         {
-            if(env->problem->properties.numberOfDiscreteVariables == 0)
+            if(env->problem->properties.numberOfDiscreteVariables == 0 && env->problem->properties.numberOfSemicontinuousVariables == 0)
             {
                 env->output->outputDebug(" Using continuous problem solution strategy.");
                 solutionStrategy = std::make_unique<SolutionStrategyNLP>(env);

--- a/src/Tasks/TaskCreateDualProblem.cpp
+++ b/src/Tasks/TaskCreateDualProblem.cpp
@@ -79,7 +79,7 @@ bool TaskCreateDualProblem::createProblem(MIPSolverPtr destination, ProblemPtr s
     for(auto& V : sourceProblem->allVariables)
     {
         variablesInitialized = variablesInitialized
-            && destination->addVariable(V->name.c_str(), V->properties.type, V->lowerBound, V->upperBound);
+            && destination->addVariable(V->name.c_str(), V->properties.type, V->lowerBound, V->upperBound, V->semiBound);
     }
 
     if(!variablesInitialized)
@@ -107,10 +107,10 @@ bool TaskCreateDualProblem::createProblem(MIPSolverPtr destination, ProblemPtr s
         destination->setDualAuxiliaryObjectiveVariableIndex(sourceProblem->properties.numberOfVariables);
 
         if(sourceProblem->objectiveFunction->properties.isMinimize)
-            destination->addVariable("shot_dual_objvar", E_VariableType::Real, objectiveBound.l(), objectiveBound.u());
+            destination->addVariable("shot_dual_objvar", E_VariableType::Real, objectiveBound.l(), objectiveBound.u(), 0.0);
         else
             destination->addVariable(
-                "shot_dual_objvar", E_VariableType::Real, -objectiveBound.u(), -objectiveBound.l());
+                "shot_dual_objvar", E_VariableType::Real, -objectiveBound.u(), -objectiveBound.l(), 0.0);
     }
 
     // Now creating the objective function

--- a/src/Tasks/TaskFindInteriorPoint.cpp
+++ b/src/Tasks/TaskFindInteriorPoint.cpp
@@ -54,23 +54,10 @@ void TaskFindInteriorPoint::run()
 
             tmpIP->point = PT->point;
 
-            for(auto& V : env->reformulatedProblem->auxiliaryVariables)
-            {
-                tmpIP->point.push_back(V->calculate(PT->point));
-            }
+            if(tmpIP->point.size() < env->reformulatedProblem->properties.numberOfVariables)
+                env->reformulatedProblem->augmentAuxiliaryVariableValues(tmpIP->point);
 
-            if(env->reformulatedProblem->auxiliaryObjectiveVariable)
-            {
-                tmpIP->point.push_back(env->reformulatedProblem->auxiliaryObjectiveVariable->calculate(PT->point));
-            }
-
-            if(env->reformulatedProblem->antiEpigraphObjectiveVariable)
-            {
-                tmpIP->point.at(env->reformulatedProblem->antiEpigraphObjectiveVariable->index)
-                    = env->reformulatedProblem->objectiveFunction->calculateValue(tmpIP->point);
-            }
-
-            assert((int)tmpIP->point.size() == env->reformulatedProblem->properties.numberOfVariables);
+            assert(tmpIP->point.size() == env->reformulatedProblem->properties.numberOfVariables);
 
             auto maxDev = env->reformulatedProblem->getMaxNumericConstraintValue(
                 tmpIP->point, env->reformulatedProblem->nonlinearConstraints);

--- a/src/Tasks/TaskInitializeIteration.cpp
+++ b/src/Tasks/TaskInitializeIteration.cpp
@@ -18,7 +18,7 @@
 namespace SHOT
 {
 
-TaskInitializeIteration::TaskInitializeIteration(EnvironmentPtr envPtr) : TaskBase(envPtr) {}
+TaskInitializeIteration::TaskInitializeIteration(EnvironmentPtr envPtr) : TaskBase(envPtr) { }
 
 TaskInitializeIteration::~TaskInitializeIteration() = default;
 

--- a/src/Tasks/TaskReformulateProblem.cpp
+++ b/src/Tasks/TaskReformulateProblem.cpp
@@ -1698,10 +1698,10 @@ std::tuple<LinearTerms, QuadraticTerms> TaskReformulateProblem::reformulateAndPa
             {
             }
             else if(useIntegerBilinearTermReformulation && T->isBilinear
-                && ((T->firstVariable->properties.type == E_VariableType::Integer
+                && (((T->firstVariable->properties.type == E_VariableType::Integer || T->firstVariable->properties.type == E_VariableType::Semiinteger)
                         && (T->firstVariable->upperBound - T->firstVariable->lowerBound
                             < maxBilinearIntegerReformulationDomain))
-                    || (T->secondVariable->properties.type == E_VariableType::Integer
+                    || ((T->secondVariable->properties.type == E_VariableType::Integer || T->secondVariable->properties.type == E_VariableType::Semiinteger)
                         && (T->secondVariable->upperBound - T->secondVariable->lowerBound
                             < maxBilinearIntegerReformulationDomain))))
             // bilinear term i1*i2 or i1*x2
@@ -1759,10 +1759,10 @@ std::tuple<LinearTerms, QuadraticTerms> TaskReformulateProblem::reformulateAndPa
                 resultLinearTerms.add(std::make_shared<LinearTerm>(signfactor * T->coefficient, auxVariable));
             }
             else if(useIntegerBilinearTermReformulation && T->isBilinear
-                && ((T->firstVariable->properties.type == E_VariableType::Integer
+                && (((T->firstVariable->properties.type == E_VariableType::Integer || T->firstVariable->properties.type == E_VariableType::Semiinteger)
                         && (T->firstVariable->upperBound - T->firstVariable->lowerBound
                             < maxBilinearIntegerReformulationDomain))
-                    || (T->secondVariable->properties.type == E_VariableType::Integer
+                    || ((T->secondVariable->properties.type == E_VariableType::Integer || T->secondVariable->properties.type == E_VariableType::Semiinteger)
                         && (T->secondVariable->upperBound - T->secondVariable->lowerBound
                             < maxBilinearIntegerReformulationDomain))))
             // bilinear term i1*i2 or i1*x2
@@ -2433,7 +2433,7 @@ std::pair<AuxiliaryVariablePtr, bool> TaskReformulateProblem::getSquareAuxiliary
     {
         variableType = E_VariableType::Binary;
     }
-    else if(variable->properties.type == E_VariableType::Integer)
+    else if(variable->properties.type == E_VariableType::Integer || variable->properties.type == E_VariableType::Semiinteger)
     {
         variableType = E_VariableType::Integer;
     }
@@ -2496,9 +2496,15 @@ std::pair<AuxiliaryVariablePtr, bool> TaskReformulateProblem::getBilinearAuxilia
         variableType = E_VariableType::Integer;
         auxVariableType = E_AuxiliaryVariableType::IntegerBilinear;
     }
+    else if(firstVariable->properties.type == E_VariableType::Semiinteger
+        && secondVariable->properties.type == E_VariableType::Semiinteger)
+    {
+        variableType = E_VariableType::Integer;
+        auxVariableType = E_AuxiliaryVariableType::IntegerBilinear;
+    }
     else if((firstVariable->properties.type == E_VariableType::Binary
-                && secondVariable->properties.type == E_VariableType::Integer)
-        || (firstVariable->properties.type == E_VariableType::Integer
+                && (secondVariable->properties.type == E_VariableType::Integer || secondVariable->properties.type == E_VariableType::Semiinteger))
+        || ((firstVariable->properties.type == E_VariableType::Integer || firstVariable->properties.type == E_VariableType::Semiinteger)
             && secondVariable->properties.type == E_VariableType::Binary))
     {
         variableType = E_VariableType::Integer;
@@ -2585,7 +2591,7 @@ void TaskReformulateProblem::createBilinearReformulations()
             reformulateBinaryContinuousBilinearTerm(firstVariable, secondVariable, AUXVAR);
             AUXVAR->properties.auxiliaryType = E_AuxiliaryVariableType::BinaryContinuousBilinear;
         }
-        else if(firstVariableType == E_VariableType::Integer || secondVariableType == E_VariableType::Integer)
+        else if(firstVariableType == E_VariableType::Integer || firstVariableType == E_VariableType::Semiinteger || secondVariableType == E_VariableType::Integer || secondVariableType == E_VariableType::Semiinteger)
         {
             reformulateIntegerBilinearTerm(firstVariable, secondVariable, AUXVAR);
             AUXVAR->properties.auxiliaryType = E_AuxiliaryVariableType::IntegerBilinear;
@@ -2681,7 +2687,8 @@ void TaskReformulateProblem::reformulateIntegerBilinearTerm(
     bool firstVariableIsDiscrete = false;
 
     if(firstVariable->properties.type == E_VariableType::Binary
-        || firstVariable->properties.type == E_VariableType::Integer)
+        || firstVariable->properties.type == E_VariableType::Integer
+        || firstVariable->properties.type == E_VariableType::Semiinteger)
     {
         foundFirstVariable
             = (integerAuxiliaryBinaryVariables.find(firstVariable) != integerAuxiliaryBinaryVariables.end());
@@ -2689,7 +2696,8 @@ void TaskReformulateProblem::reformulateIntegerBilinearTerm(
     }
 
     if(secondVariable->properties.type == E_VariableType::Binary
-        || secondVariable->properties.type == E_VariableType::Integer)
+        || secondVariable->properties.type == E_VariableType::Integer
+        || secondVariable->properties.type == E_VariableType::Semiinteger)
     {
         foundSecondVariable
             = (integerAuxiliaryBinaryVariables.find(secondVariable) != integerAuxiliaryBinaryVariables.end());

--- a/src/Tasks/TaskReformulateProblem.cpp
+++ b/src/Tasks/TaskReformulateProblem.cpp
@@ -199,7 +199,8 @@ TaskReformulateProblem::TaskReformulateProblem(EnvironmentPtr envPtr) : TaskBase
     // Copying variables
     for(auto& V : env->problem->allVariables)
     {
-        auto variable = std::make_shared<Variable>(V->name, V->index, V->properties.type, V->lowerBound, V->upperBound);
+        auto variable = std::make_shared<Variable>(
+            V->name, V->index, V->properties.type, V->lowerBound, V->upperBound, V->semiBound);
 
         variable->properties.hasLowerBoundBeenTightened = V->properties.hasLowerBoundBeenTightened;
         variable->properties.hasUpperBoundBeenTightened = V->properties.hasUpperBoundBeenTightened;
@@ -1698,10 +1699,12 @@ std::tuple<LinearTerms, QuadraticTerms> TaskReformulateProblem::reformulateAndPa
             {
             }
             else if(useIntegerBilinearTermReformulation && T->isBilinear
-                && (((T->firstVariable->properties.type == E_VariableType::Integer || T->firstVariable->properties.type == E_VariableType::Semiinteger)
+                && (((T->firstVariable->properties.type == E_VariableType::Integer
+                         || T->firstVariable->properties.type == E_VariableType::Semiinteger)
                         && (T->firstVariable->upperBound - T->firstVariable->lowerBound
                             < maxBilinearIntegerReformulationDomain))
-                    || ((T->secondVariable->properties.type == E_VariableType::Integer || T->secondVariable->properties.type == E_VariableType::Semiinteger)
+                    || ((T->secondVariable->properties.type == E_VariableType::Integer
+                            || T->secondVariable->properties.type == E_VariableType::Semiinteger)
                         && (T->secondVariable->upperBound - T->secondVariable->lowerBound
                             < maxBilinearIntegerReformulationDomain))))
             // bilinear term i1*i2 or i1*x2
@@ -1759,10 +1762,12 @@ std::tuple<LinearTerms, QuadraticTerms> TaskReformulateProblem::reformulateAndPa
                 resultLinearTerms.add(std::make_shared<LinearTerm>(signfactor * T->coefficient, auxVariable));
             }
             else if(useIntegerBilinearTermReformulation && T->isBilinear
-                && (((T->firstVariable->properties.type == E_VariableType::Integer || T->firstVariable->properties.type == E_VariableType::Semiinteger)
+                && (((T->firstVariable->properties.type == E_VariableType::Integer
+                         || T->firstVariable->properties.type == E_VariableType::Semiinteger)
                         && (T->firstVariable->upperBound - T->firstVariable->lowerBound
                             < maxBilinearIntegerReformulationDomain))
-                    || ((T->secondVariable->properties.type == E_VariableType::Integer || T->secondVariable->properties.type == E_VariableType::Semiinteger)
+                    || ((T->secondVariable->properties.type == E_VariableType::Integer
+                            || T->secondVariable->properties.type == E_VariableType::Semiinteger)
                         && (T->secondVariable->upperBound - T->secondVariable->lowerBound
                             < maxBilinearIntegerReformulationDomain))))
             // bilinear term i1*i2 or i1*x2
@@ -2433,7 +2438,8 @@ std::pair<AuxiliaryVariablePtr, bool> TaskReformulateProblem::getSquareAuxiliary
     {
         variableType = E_VariableType::Binary;
     }
-    else if(variable->properties.type == E_VariableType::Integer || variable->properties.type == E_VariableType::Semiinteger)
+    else if(variable->properties.type == E_VariableType::Integer
+        || variable->properties.type == E_VariableType::Semiinteger)
     {
         variableType = E_VariableType::Integer;
     }
@@ -2503,8 +2509,10 @@ std::pair<AuxiliaryVariablePtr, bool> TaskReformulateProblem::getBilinearAuxilia
         auxVariableType = E_AuxiliaryVariableType::IntegerBilinear;
     }
     else if((firstVariable->properties.type == E_VariableType::Binary
-                && (secondVariable->properties.type == E_VariableType::Integer || secondVariable->properties.type == E_VariableType::Semiinteger))
-        || ((firstVariable->properties.type == E_VariableType::Integer || firstVariable->properties.type == E_VariableType::Semiinteger)
+                && (secondVariable->properties.type == E_VariableType::Integer
+                    || secondVariable->properties.type == E_VariableType::Semiinteger))
+        || ((firstVariable->properties.type == E_VariableType::Integer
+                || firstVariable->properties.type == E_VariableType::Semiinteger)
             && secondVariable->properties.type == E_VariableType::Binary))
     {
         variableType = E_VariableType::Integer;
@@ -2591,7 +2599,8 @@ void TaskReformulateProblem::createBilinearReformulations()
             reformulateBinaryContinuousBilinearTerm(firstVariable, secondVariable, AUXVAR);
             AUXVAR->properties.auxiliaryType = E_AuxiliaryVariableType::BinaryContinuousBilinear;
         }
-        else if(firstVariableType == E_VariableType::Integer || firstVariableType == E_VariableType::Semiinteger || secondVariableType == E_VariableType::Integer || secondVariableType == E_VariableType::Semiinteger)
+        else if(firstVariableType == E_VariableType::Integer || firstVariableType == E_VariableType::Semiinteger
+            || secondVariableType == E_VariableType::Integer || secondVariableType == E_VariableType::Semiinteger)
         {
             reformulateIntegerBilinearTerm(firstVariable, secondVariable, AUXVAR);
             AUXVAR->properties.auxiliaryType = E_AuxiliaryVariableType::IntegerBilinear;

--- a/src/Tasks/TaskSelectPrimalCandidatesFromNLP.cpp
+++ b/src/Tasks/TaskSelectPrimalCandidatesFromNLP.cpp
@@ -132,6 +132,11 @@ TaskSelectPrimalCandidatesFromNLP::TaskSelectPrimalCandidatesFromNLP(Environment
         discreteVariableIndexes.push_back(V->index);
     }
 
+    for(auto& V : sourceProblem->semiintegerVariables)
+    {
+        discreteVariableIndexes.push_back(V->index);
+    }
+
     if(env->settings->getSetting<bool>("Debug.Enable", "Output"))
     {
         for(auto& V : sourceProblem->allVariables)

--- a/src/Tasks/TaskSelectPrimalCandidatesFromNLP.cpp
+++ b/src/Tasks/TaskSelectPrimalCandidatesFromNLP.cpp
@@ -514,21 +514,10 @@ void TaskSelectPrimalCandidatesFromNLP::createInfeasibilityCut(const VectorDoubl
     if(!sourceIsReformulatedProblem) // Need to calculate values for the auxiliary variables in this
                                      // case
     {
-        for(auto& V : env->reformulatedProblem->auxiliaryVariables)
-        {
-            tmpSolPt.point.push_back(V->calculate(variableSolution));
-        }
+        if(tmpSolPt.point.size() < env->reformulatedProblem->properties.numberOfVariables)
+            env->reformulatedProblem->augmentAuxiliaryVariableValues(tmpSolPt.point);
 
-        if(env->reformulatedProblem->auxiliaryObjectiveVariable)
-        {
-            tmpSolPt.point.push_back(env->reformulatedProblem->auxiliaryObjectiveVariable->calculate(variableSolution));
-        }
-
-        if(env->reformulatedProblem->antiEpigraphObjectiveVariable)
-        {
-            tmpSolPt.point.at(env->reformulatedProblem->antiEpigraphObjectiveVariable->index)
-                = env->reformulatedProblem->objectiveFunction->calculateValue(tmpSolPt.point);
-        }
+        assert(tmpSolPt.point.size() == env->reformulatedProblem->properties.numberOfVariables);
     }
 
     std::vector<SolutionPoint> solutionPoints(1);

--- a/src/Tasks/TaskSelectPrimalCandidatesFromRootsearch.cpp
+++ b/src/Tasks/TaskSelectPrimalCandidatesFromRootsearch.cpp
@@ -69,6 +69,11 @@ void TaskSelectPrimalCandidatesFromRootsearch::run(std::vector<SolutionPoint> so
                     xNLP.at(V->index) = P.point.at(V->index);
                 }
 
+                for(auto& V : env->reformulatedProblem->semiintegerVariables)
+                {
+                    xNLP.at(V->index) = P.point.at(V->index);
+                }
+
                 auto maxDevNLP2 = env->reformulatedProblem->getMaxNumericConstraintValue(
                     xNLP, env->reformulatedProblem->numericConstraints);
                 auto maxDevMIP = env->reformulatedProblem->getMaxNumericConstraintValue(

--- a/src/Tasks/TaskUpdateInteriorPoint.cpp
+++ b/src/Tasks/TaskUpdateInteriorPoint.cpp
@@ -44,11 +44,10 @@ void TaskUpdateInteriorPoint::run()
     {
         auto tmpIP = std::make_shared<InteriorPoint>();
 
-        for(auto& VAR : env->reformulatedProblem->auxiliaryVariables)
-            tmpPrimalPoint.push_back(VAR->calculate(tmpPrimalPoint));
+        if(tmpPrimalPoint.size() < env->reformulatedProblem->properties.numberOfVariables)
+            env->reformulatedProblem->augmentAuxiliaryVariableValues(tmpPrimalPoint);
 
-        if(env->reformulatedProblem->auxiliaryObjectiveVariable)
-            tmpPrimalPoint.push_back(env->reformulatedProblem->auxiliaryObjectiveVariable->calculate(tmpPrimalPoint));
+        assert(tmpPrimalPoint.size() == env->reformulatedProblem->properties.numberOfVariables);
 
         tmpIP->point = tmpPrimalPoint;
         assert((int)tmpIP->point.size() == env->reformulatedProblem->properties.numberOfVariables);
@@ -74,18 +73,12 @@ void TaskUpdateInteriorPoint::run()
     // Need to calculate the value for the point in the reformulated problem
     auto tmpIP = std::make_shared<InteriorPoint>();
 
-    for(auto& VAR : env->reformulatedProblem->auxiliaryVariables)
-        tmpPrimalPoint.push_back(VAR->calculate(tmpPrimalPoint));
+    if(tmpPrimalPoint.size() < env->reformulatedProblem->properties.numberOfVariables)
+        env->reformulatedProblem->augmentAuxiliaryVariableValues(tmpPrimalPoint);
 
-    if(env->reformulatedProblem->auxiliaryObjectiveVariable)
-        tmpPrimalPoint.push_back(env->reformulatedProblem->auxiliaryObjectiveVariable->calculate(tmpPrimalPoint));
-
-    if(env->reformulatedProblem->antiEpigraphObjectiveVariable)
-        tmpPrimalPoint.at(env->reformulatedProblem->antiEpigraphObjectiveVariable->index)
-            = env->reformulatedProblem->objectiveFunction->calculateValue(tmpPrimalPoint);
+    assert(tmpPrimalPoint.size() == env->reformulatedProblem->properties.numberOfVariables);
 
     tmpIP->point = tmpPrimalPoint;
-    assert((int)tmpIP->point.size() == env->reformulatedProblem->properties.numberOfVariables);
 
     auto maxDev = env->reformulatedProblem->getMaxNumericConstraintValue(
         tmpIP->point, env->reformulatedProblem->nonlinearConstraints);
@@ -132,22 +125,14 @@ void TaskUpdateInteriorPoint::run()
         auto tmpIP = std::make_shared<InteriorPoint>();
 
         for(size_t i = 0; i < tmpPrimalPoint.size(); i++)
-        {
             tmpPrimalPoint.at(i) = (0.5 * tmpPrimalPoint.at(i) + 0.5 * env->dualSolver->interiorPts.at(0)->point.at(i));
-        }
 
-        for(auto& VAR : env->reformulatedProblem->auxiliaryVariables)
-            tmpPrimalPoint.push_back(VAR->calculate(tmpPrimalPoint));
+        if(tmpPrimalPoint.size() < env->reformulatedProblem->properties.numberOfVariables)
+            env->reformulatedProblem->augmentAuxiliaryVariableValues(tmpPrimalPoint);
 
-        if(env->reformulatedProblem->auxiliaryObjectiveVariable)
-            tmpPrimalPoint.push_back(env->reformulatedProblem->auxiliaryObjectiveVariable->calculate(tmpPrimalPoint));
-
-        if(env->reformulatedProblem->antiEpigraphObjectiveVariable)
-            tmpPrimalPoint.at(env->reformulatedProblem->antiEpigraphObjectiveVariable->index)
-                = env->reformulatedProblem->objectiveFunction->calculateValue(tmpPrimalPoint);
+        assert(tmpPrimalPoint.size() == env->reformulatedProblem->properties.numberOfVariables);
 
         tmpIP->point = tmpPrimalPoint;
-        assert((int)tmpIP->point.size() == env->reformulatedProblem->properties.numberOfVariables);
 
         auto maxDev = env->reformulatedProblem->getMaxNumericConstraintValue(
             tmpIP->point, env->reformulatedProblem->nonlinearConstraints);

--- a/src/Utilities.cpp
+++ b/src/Utilities.cpp
@@ -530,7 +530,7 @@ template <typename T> double calculateHash(std::vector<T> const& point)
 
 bool isAlmostEqual(double x, double y, const double epsilon) { return std::abs(x - y) <= epsilon * std::abs(x); }
 
-bool isAlmostZero(double x) { return std::abs(x) < std::numeric_limits<double>::epsilon(); }
+bool isAlmostZero(double x, const double epsilon) { return std::abs(x) < epsilon; }
 
 std::string trim(std::string& str)
 {

--- a/src/Utilities.h
+++ b/src/Utilities.h
@@ -111,7 +111,7 @@ template <typename T> double calculateHash(std::vector<T> const& point);
 
 bool isAlmostEqual(double x, double y, const double epsilon);
 
-bool isAlmostZero(double x);
+bool isAlmostZero(double x, const double epsilon = std::numeric_limits<double>::epsilon());
 
 bool isInteger(double value);
 std::string trim(std::string& str);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,17 +21,17 @@ set(Model_parts
 set(Settings_parts 1 2)
 
 if(HAS_CBC)
-  set(Cbc_parts 1 2)
+  set(Cbc_parts 1 2 3)
   set(cpptests ${cpptests} Cbc)
 endif()
 
 if(HAS_CPLEX)
-  set(Cplex_parts 1 2)
+  set(Cplex_parts 1 2 3)
   set(cpptests ${cpptests} Cplex)
 endif()
 
 if(HAS_GUROBI)
-  set(Gurobi_parts 1 2)
+  set(Gurobi_parts 1 2 3)
   set(cpptests ${cpptests} Gurobi)
 endif()
 
@@ -45,7 +45,9 @@ if(HAS_GAMS)
       6
       7
       8
-      9)
+      9
+      10
+      11)
   set(cpptests ${cpptests} GAMS)
 endif()
 
@@ -54,7 +56,8 @@ set(Solver_parts
     2
     3
     4
-    5)
+    5
+    6)
 set(cpptests ${cpptests} Solver)
 
 if(HAS_IPOPT)

--- a/test/CbcTest.cpp
+++ b/test/CbcTest.cpp
@@ -144,6 +144,11 @@ int CbcTest(int argc, char* argv[])
         passed = CbcTerminationCallbackTest("data/tls2.osil");
         std::cout << "Finished test checking termination callback in Cbc." << std::endl;
         break;
+    case 3:
+        std::cout << "Starting test to solve problem with semicont. variables:" << std::endl;
+        passed = CbcTest1("data/meanvarxsc.osil");
+        std::cout << "Finished test to solve problem with semicont. variables." << std::endl;
+        break;
     default:
         passed = false;
         std::cout << "Test #" << choice << " does not exist!\n";

--- a/test/CplexTest.cpp
+++ b/test/CplexTest.cpp
@@ -130,7 +130,7 @@ int CplexTest(int argc, char* argv[])
     switch(choice)
     {
     case 1:
-        std::cout << "Starting test to solve a MINLP problem with Cplex" << std::endl;
+        std::cout << "Starting test to solve a MINLP problem with Cplex:" << std::endl;
         passed = CplexTest1("data/tls2.osil");
         std::cout << "Finished test to solve a MINLP problem with Cplex." << std::endl;
         break;
@@ -138,6 +138,11 @@ int CplexTest(int argc, char* argv[])
         std::cout << "Starting test to check termination callback in Cplex:" << std::endl;
         passed = CplexTerminationCallbackTest("data/tls2.osil");
         std::cout << "Finished test checking termination callback in Cplex." << std::endl;
+        break;
+    case 3:
+        std::cout << "Starting test to solve problem with semicont. variables with Cplex:" << std::endl;
+        passed = CplexTest1("data/meanvarxsc.osil");
+        std::cout << "Finished test to solve problem with semicont. variables with Cplex." << std::endl;
         break;
     default:
         passed = false;

--- a/test/GAMSTest.cpp
+++ b/test/GAMSTest.cpp
@@ -355,6 +355,13 @@ int GAMSTest(int argc, char* argv[])
         passed = SolveProblemGAMS("data/sos3.gms");
         std::cout << "Finished test to solve problem sos3 with SOS1 and SOS2 constraints in GAMS syntax." << std::endl;
         break;
+    case 11:
+        std::cout << "Starting test to solve problem meanvarxsc with semi continuous variables in GAMS syntax:"
+                  << std::endl;
+        passed = SolveProblemGAMS("data/meanvarxsc.gms");
+        std::cout << "Finished test to solve problem meanvarxsc with semi continuous variables in GAMS syntax."
+                  << std::endl;
+        break;
     default:
         passed = false;
         std::cout << "Test #" << choice << " does not exist!\n";

--- a/test/GurobiTest.cpp
+++ b/test/GurobiTest.cpp
@@ -145,6 +145,11 @@ int GurobiTest(int argc, char* argv[])
         passed = GurobiTerminationCallbackTest("data/tls2.osil");
         std::cout << "Finished test checking termination callback in Gurobi." << std::endl;
         break;
+    case 3:
+        std::cout << "Starting test to solve problem with semicont. variables with Gurobi.:" << std::endl;
+        passed = GurobiTest1("data/meanvarxsc.osil");
+        std::cout << "Finished test to solve problem with semicont. variables with Gurobi." << std::endl;
+        break;
     default:
         passed = false;
         std::cout << "Test #" << choice << " does not exist!\n";

--- a/test/SolverTest.cpp
+++ b/test/SolverTest.cpp
@@ -458,6 +458,11 @@ int SolverTest(int argc, char* argv[])
         passed = CreateAndSolveProblem();
         std::cout << "Finished test solving model using SHOT API." << std::endl;
         break;
+    case 6:
+        std::cout << "Starting test to read OSiL file with semicont. variables:" << std::endl;
+        passed = ReadProblem("data/meanvarxsc.osil");
+        std::cout << "Finished test to read OSiL file with semicont. variables." << std::endl;
+        break;
     default:
         passed = false;
         std::cout << "Test #" << choice << " does not exist!\n";


### PR DESCRIPTION
This adds handling of semiContinuous variables to the Cbc interface.

But more importantly, SHOT itself didn't seem to take much into account that the bounds stored for a semicontinuous variable were not the actual bounds, i.e., the feasible 0 point seem to have been ignored.
So with the changes here, the variable bounds are now the actual bounds also for a semicontinuous variable and another member semiBound is added to store the (typically) lower bound if not away from 0.

Also change code so that semicontinuous variables {0} or in [lb,ub] with ub < 0 should be possible.

If I run this on meanvarxsc with CPLEX, things look good.
With Cbc, it doesn't (valgrind reports invalid reads when eval a quadratic expr with an auxvar; asserts in Cbc fail, and more from the address sanitizer).

Since I was here anyway, I also added support for seminteger variables by just duplicating code for semicontinuous vars.