### PR TITLE
Fix compilation error on Windows with IGNORE enum

### DIFF
--- a/src/ModelingSystem/ModelingSystemAMPL.cpp
+++ b/src/ModelingSystem/ModelingSystemAMPL.cpp
@@ -416,12 +416,12 @@ public:
     private:
         AMPLProblemHandler& amplph;
 
-        // type of suffix that is handled, or IGNORE if unsupported suffix
+        // type of suffix that is handled, or SUFFIX_IGNORE if unsupported suffix
         enum
         {
-            IGNORE,
-            VARSOSNO,
-            VARREF,
+            SUFFIX_IGNORE,
+            SUFFIX_VARSOSNO,
+            SUFFIX_VARREF,
         } suffix;
 
     public:
@@ -430,7 +430,7 @@ public:
             fmtold::StringRef name, ///< name of suffix
             mp::suf::Kind kind ///< whether suffix applies to var, cons, etc
             )
-            : amplph(amplph_), suffix(IGNORE)
+            : amplph(amplph_), suffix(SUFFIX_IGNORE)
         {
             switch(kind)
             {
@@ -445,12 +445,12 @@ public:
                 if(strncmp(name.data(), "sosno", name.size()) == 0)
                 {
                     // SOS membership
-                    suffix = VARSOSNO;
+                    suffix = SUFFIX_VARSOSNO;
                 }
                 else if(strncmp(name.data(), "ref", name.size()) == 0)
                 {
                     // SOS weights
-                    suffix = VARREF;
+                    suffix = SUFFIX_VARREF;
                     amplph.sosweights.resize(amplph.destination->allVariables.size(), 0);
                 }
                 else
@@ -481,15 +481,15 @@ public:
             assert(index >= 0);
             switch(suffix)
             {
-            case IGNORE:
+            case SUFFIX_IGNORE:
                 return;
 
-            case VARSOSNO:
+            case SUFFIX_VARSOSNO:
                 // remember that variable index belongs to SOS identified by value
                 amplph.sosvars[(int)value].push_back(index);
                 break;
 
-            case VARREF:
+            case SUFFIX_VARREF:
                 // remember that variable index has weight value
                 amplph.sosweights[index] = (int)value;
                 break;


### PR DESCRIPTION
This was causing failures on our Windows builds: https://github.com/JuliaPackaging/Yggdrasil/pull/3290

Log: https://dev.azure.com/JuliaPackaging/Yggdrasil/_build/results?buildId=12199&view=logs&j=471210ec-aeb4-55ba-6241-1758b9a7523b&t=5a065a53-39d1-5f7d-e4f1-5d21ed2e419d&l=36323

I didn't track the source of the problem, but I guess Windows defines an IGNORE constant somewhere else.