### PR TITLE
switch to solvelink=2 if calling GAMS/IPOPT

### DIFF
--- a/src/NLPSolver/NLPSolverGAMS.h
+++ b/src/NLPSolver/NLPSolverGAMS.h
@@ -28,6 +28,7 @@ private:
     double timelimit;
     int iterlimit;
     bool showlog;
+    int solvelink;
 
 public:
     NLPSolverGAMS(EnvironmentPtr envPtr, gmoHandle_t modelingObject, palHandle_t auditLicensing);


### PR DESCRIPTION
One weekend and I had forgotten what I wrote on Friday.

So, as alternative to #136, instead of forbidding GAMS/IPOPT(H), it switches the solvelink option to 2. This makes gev write out the problem instance to a GAMS control file and then calls GAMS/IPOPT(H) as a separate process.
A bit slower, but should not crash.