### PR TITLE
adjust to changes in boost 1.77.0

### DIFF
--- a/src/NLPSolver/NLPSolverCuttingPlaneMinimax.cpp
+++ b/src/NLPSolver/NLPSolverCuttingPlaneMinimax.cpp
@@ -22,6 +22,7 @@
 #include <map>
 
 #include "boost/math/tools/minima.hpp"
+#include "boost/version.hpp"
 
 namespace SHOT
 {
@@ -116,7 +117,7 @@ E_NLPSolutionStatus NLPSolverCuttingPlaneMinimax::solveProblemInstance()
         = env->settings->getSetting<double>("ESH.InteriorPoint.CuttingPlane.TerminationToleranceRel", "Dual");
     double constrSelFactor
         = env->settings->getSetting<double>("ESH.InteriorPoint.CuttingPlane.ConstraintSelectionFactor", "Dual");
-    boost::uintmax_t maxIterSubsolver
+    int maxIterSubsolver
         = env->settings->getSetting<int>("ESH.InteriorPoint.CuttingPlane.IterationLimitSubsolver", "Dual");
     int bitPrecision = env->settings->getSetting<int>("ESH.InteriorPoint.CuttingPlane.BitPrecision", "Dual");
 
@@ -141,7 +142,12 @@ E_NLPSolutionStatus NLPSolverCuttingPlaneMinimax::solveProblemInstance()
 
     for(int i = 0; i <= maxIter; i++)
     {
+        // boost 1.77.0 changed from boost::uintmax_t to std::uintmax_t
+#if defined(BOOST_VERSION) && BOOST_VERSION >= 107700
+        std::uintmax_t maxIterSubsolverTmp = maxIterSubsolver;
+#else
         boost::uintmax_t maxIterSubsolverTmp = maxIterSubsolver;
+#endif
 
         // Saves the LP problem to file if in debug mode
         if(env->settings->getSetting<bool>("Debug.Enable", "Output"))
@@ -217,7 +223,7 @@ E_NLPSolutionStatus NLPSolverCuttingPlaneMinimax::solveProblemInstance()
         {
             MinimizationFunction funct(LPVarSol, prevSol, sourceProblem);
 
-            // Solves the minization problem wrt lambda in [0, 1]
+            // Solves the minimization problem wrt lambda in [0, 1]
             auto minimizationResult
                 = boost::math::tools::brent_find_minima(funct, 0.0, 1.0, bitPrecision, maxIterSubsolverTmp);
 

--- a/src/NLPSolver/NLPSolverCuttingPlaneMinimax.cpp
+++ b/src/NLPSolver/NLPSolverCuttingPlaneMinimax.cpp
@@ -22,7 +22,7 @@
 #include <map>
 
 #include "boost/math/tools/minima.hpp"
-#include "boost/version.hpp"
+#include "boost/cstdint.hpp"
 
 namespace SHOT
 {
@@ -142,12 +142,7 @@ E_NLPSolutionStatus NLPSolverCuttingPlaneMinimax::solveProblemInstance()
 
     for(int i = 0; i <= maxIter; i++)
     {
-        // boost 1.77.0 changed from boost::uintmax_t to std::uintmax_t
-#if defined(BOOST_VERSION) && BOOST_VERSION >= 107700
-        std::uintmax_t maxIterSubsolverTmp = maxIterSubsolver;
-#else
         boost::uintmax_t maxIterSubsolverTmp = maxIterSubsolver;
-#endif
 
         // Saves the LP problem to file if in debug mode
         if(env->settings->getSetting<bool>("Debug.Enable", "Output"))

--- a/src/RootsearchMethod/RootsearchMethodBoost.cpp
+++ b/src/RootsearchMethod/RootsearchMethodBoost.cpp
@@ -17,6 +17,7 @@
 #include "../Iteration.h"
 
 #include "boost/math/tools/roots.hpp"
+#include "boost/cstdint.hpp"
 
 namespace SHOT
 {


### PR DESCRIPTION
There was a change in boost (boostorg/math@fc9891cccd7ff595bf67bf88ca6a8ac38ae7a9c8) that broke compilation of `NLPSolverCuttingPlaneMinimax` because the signature of `boost::math::tools::brent_find_minima()` changed (now expecting `std::uintmax_t` instead of `boost::uintmax_t`).
This PR adapts to this change.

An alternative may have been to include `boost/cstdint.hpp` to get `boost::uintmax_t` back. I haven't tried that.
