### PR TITLE
GAMS parsing improvements

### DIFF
--- a/src/Model/NonlinearExpressions.h
+++ b/src/Model/NonlinearExpressions.h
@@ -198,6 +198,11 @@ public:
     };
 
     inline void add(NonlinearExpressionPtr expression) { (*this).push_back(expression); };
+    inline void add(NonlinearExpressions expressions)
+    {
+        for(auto& E : expressions)
+            (*this).push_back(E);
+    };
 };
 
 class ExpressionConstant : public NonlinearExpression

--- a/src/Model/NonlinearExpressions.h
+++ b/src/Model/NonlinearExpressions.h
@@ -399,7 +399,7 @@ public:
 
     inline std::ostream& print(std::ostream& stream) const override
     {
-        stream << "(-" << child << ')';
+        stream << "-" << child;
         return stream;
     }
 
@@ -499,7 +499,7 @@ public:
 
     inline std::ostream& print(std::ostream& stream) const override
     {
-        stream << "1/(" << child << ')';
+        stream << "1/" << child;
         return stream;
     }
 
@@ -1930,7 +1930,7 @@ public:
 
     inline std::ostream& print(std::ostream& stream) const override
     {
-        stream << '(' << firstChild << ")^(" << secondChild << ')';
+        stream << firstChild << "^" << secondChild;
         return stream;
     }
 

--- a/src/Model/Simplifications.h
+++ b/src/Model/Simplifications.h
@@ -745,18 +745,13 @@ inline NonlinearExpressionPtr simplifyExpression(std::shared_ptr<ExpressionSum> 
         }
     }
 
-    auto sum = std::make_shared<ExpressionSum>();
-
-    if(constant != 0.0)
-        sum->children.add(std::make_shared<ExpressionConstant>(constant));
-
     if(children.size() == 0 && linearVariableCoefficients.size() == 0) // Everything has been simplified away
         return (std::make_shared<ExpressionConstant>(constant));
 
-    for(auto& C : children)
-    {
-        sum->children.add(C);
-    }
+    auto sum = std::make_shared<ExpressionSum>(children);
+
+    if(constant != 0.0)
+        sum->children.add(std::make_shared<ExpressionConstant>(constant));
 
     for(auto& P : linearVariableCoefficients)
     {

--- a/src/ModelingSystem/ModelingSystemAMPL.cpp
+++ b/src/ModelingSystem/ModelingSystemAMPL.cpp
@@ -13,6 +13,7 @@
 #include "../Output.h"
 #include "../Results.h"
 #include "../Settings.h"
+#include "../Timing.h"
 #include "../Utilities.h"
 
 #include "../Model/NonlinearExpressions.h"
@@ -339,13 +340,13 @@ public:
         else
             destination->objectiveFunction->direction = E_ObjectiveFunctionDirection::Minimize;
 
-        if(nonlinearExpression) 
+        if(nonlinearExpression)
         {
-            if (nonlinearExpression->getType() == E_NonlinearExpressionTypes::Constant)
+            if(nonlinearExpression->getType() == E_NonlinearExpressionTypes::Constant)
             {
                 destination->objectiveFunction->constant += nonlinearExpression->getBounds().l();
             }
-            else 
+            else
             {
                 std::dynamic_pointer_cast<NonlinearObjectiveFunction>(destination->objectiveFunction)
                     ->add(nonlinearExpression);
@@ -661,8 +662,11 @@ E_ProblemCreationStatus ModelingSystemAMPL::createProblem(ProblemPtr& problem, c
     {
         env->output->outputError("Problem file \"" + filename + "\" does not exist.");
 
+        env->timing->stopTimer("ProblemInitialization");
         return (E_ProblemCreationStatus::FileDoesNotExist);
     }
+
+    env->timing->startTimer("ProblemInitialization");
 
     fs::filesystem::path problemFile(filename);
     fs::filesystem::path problemPath = problemFile.parent_path();
@@ -676,6 +680,7 @@ E_ProblemCreationStatus ModelingSystemAMPL::createProblem(ProblemPtr& problem, c
     {
         env->output->outputError(fmt::format("Error when reading AMPL model from \"{}\": {}", filename, e.what()));
 
+        env->timing->stopTimer("ProblemInitialization");
         return (E_ProblemCreationStatus::Error);
     }
 
@@ -725,6 +730,7 @@ E_ProblemCreationStatus ModelingSystemAMPL::createProblem(ProblemPtr& problem, c
 
     problem->finalize();
 
+    env->timing->stopTimer("ProblemInitialization");
     return (E_ProblemCreationStatus::NormalCompletion);
 }
 

--- a/src/ModelingSystem/ModelingSystemGAMS.cpp
+++ b/src/ModelingSystem/ModelingSystemGAMS.cpp
@@ -1612,7 +1612,7 @@ NonlinearExpressionPtr ModelingSystemGAMS::parseGamsInstructions(int codelen, /*
                 else
                 {
                     auto expression = std::make_shared<ExpressionSum>(
-                        std::make_shared<ExpressionConstant>(variable->lowerBound), stack.rbegin()[0]);
+                        std::make_shared<ExpressionConstant>(variable->lowerBound), std::move(stack.rbegin()[0]));
                     stack.pop_back();
                     stack.push_back(std::move(expression));
                 }
@@ -1627,7 +1627,7 @@ NonlinearExpressionPtr ModelingSystemGAMS::parseGamsInstructions(int codelen, /*
                 else
                 {
                     auto expression = std::make_shared<ExpressionSum>(
-                        std::make_shared<ExpressionVariable>(variable), stack.rbegin()[0]);
+                        std::make_shared<ExpressionVariable>(variable), std::move(stack.rbegin()[0]));
                     stack.pop_back();
                     stack.push_back(std::move(expression));
                 }
@@ -1757,7 +1757,7 @@ NonlinearExpressionPtr ModelingSystemGAMS::parseGamsInstructions(int codelen, /*
                 else
                 {
                     auto expression = std::make_shared<ExpressionProduct>(
-                        std::make_shared<ExpressionConstant>(variable->lowerBound), stack.rbegin()[0]);
+                        std::make_shared<ExpressionConstant>(variable->lowerBound), std::move(stack.rbegin()[0]));
                     stack.pop_back();
                     stack.push_back(std::move(expression));
                 }
@@ -1772,7 +1772,7 @@ NonlinearExpressionPtr ModelingSystemGAMS::parseGamsInstructions(int codelen, /*
                 else
                 {
                     auto expression = std::make_shared<ExpressionProduct>(
-                        std::make_shared<ExpressionVariable>(variable), stack.rbegin()[0]);
+                        std::make_shared<ExpressionVariable>(variable), std::move(stack.rbegin()[0]));
                     stack.pop_back();
                     stack.push_back(std::move(expression));
                 }
@@ -1808,11 +1808,22 @@ NonlinearExpressionPtr ModelingSystemGAMS::parseGamsInstructions(int codelen, /*
             stack.pop_back();
             stack.push_back(std::move(expressionProduct));
 
-            auto expressionSum
-                = std::make_shared<ExpressionSum>(std::move(stack.rbegin()[1]), std::move(stack.rbegin()[0]));
-            stack.pop_back();
-            stack.pop_back();
-            stack.push_back(std::move(expressionSum));
+            bool prevIsSum = (stack.rbegin()[1]->getType() == E_NonlinearExpressionTypes::Sum);
+
+            if(prevIsSum)
+            {
+                std::static_pointer_cast<ExpressionSum>(stack.rbegin()[1])->children.add(std::move(stack.rbegin()[0]));
+                stack.pop_back();
+            }
+            else
+            {
+                auto expressionSum
+                    = std::make_shared<ExpressionSum>(std::move(stack.rbegin()[1]), std::move(stack.rbegin()[0]));
+                stack.pop_back();
+                stack.pop_back();
+                stack.push_back(std::move(expressionSum));
+            }
+
             break;
         }
 

--- a/src/ModelingSystem/ModelingSystemGAMS.cpp
+++ b/src/ModelingSystem/ModelingSystemGAMS.cpp
@@ -1563,20 +1563,20 @@ NonlinearExpressionPtr ModelingSystemGAMS::parseGamsInstructions(int codelen, /*
 
             if(child1IsSum && child0IsSum) // Add children of last element on stack to the previous element's children
             {
-                std::dynamic_pointer_cast<ExpressionSum>(stack.rbegin()[1])
-                    ->children.add(std::move(std::dynamic_pointer_cast<ExpressionSum>(stack.rbegin()[0])->children));
+                std::static_pointer_cast<ExpressionSum>(stack.rbegin()[1])
+                    ->children.add(std::move(std::static_pointer_cast<ExpressionSum>(stack.rbegin()[0])->children));
                 stack.pop_back();
             }
             else if(child1IsSum) // Add last element on stack to the previous element's children
             {
-                std::dynamic_pointer_cast<ExpressionSum>(stack.rbegin()[1])->children.add(std::move(stack.rbegin()[0]));
+                std::static_pointer_cast<ExpressionSum>(stack.rbegin()[1])->children.add(std::move(stack.rbegin()[0]));
                 stack.pop_back();
             }
             else if(child0IsSum) // Add the element before the last element on stack to the last element's children,
                                  // remove the last two from stack and readd the correct one
             {
                 auto tmpElement = stack.rbegin()[0];
-                std::dynamic_pointer_cast<ExpressionSum>(tmpElement)->children.add(std::move(stack.rbegin()[1]));
+                std::static_pointer_cast<ExpressionSum>(tmpElement)->children.add(std::move(stack.rbegin()[1]));
                 stack.pop_back();
                 stack.pop_back();
                 stack.push_back(tmpElement);
@@ -1606,7 +1606,7 @@ NonlinearExpressionPtr ModelingSystemGAMS::parseGamsInstructions(int codelen, /*
             {
                 if(mainIsSum)
                 {
-                    std::dynamic_pointer_cast<ExpressionSum>(stack.rbegin()[0])
+                    std::static_pointer_cast<ExpressionSum>(stack.rbegin()[0])
                         ->children.add(std::make_shared<ExpressionConstant>(variable->lowerBound));
                 }
                 else
@@ -1621,7 +1621,7 @@ NonlinearExpressionPtr ModelingSystemGAMS::parseGamsInstructions(int codelen, /*
             {
                 if(mainIsSum)
                 {
-                    std::dynamic_pointer_cast<ExpressionSum>(stack.rbegin()[0])
+                    std::static_pointer_cast<ExpressionSum>(stack.rbegin()[0])
                         ->children.add(std::make_shared<ExpressionVariable>(variable));
                 }
                 else
@@ -1651,7 +1651,7 @@ NonlinearExpressionPtr ModelingSystemGAMS::parseGamsInstructions(int codelen, /*
 
             if(mainIsSum)
             {
-                std::dynamic_pointer_cast<ExpressionSum>(stack.rbegin()[1])
+                std::static_pointer_cast<ExpressionSum>(stack.rbegin()[1])
                     ->children.add(std::make_shared<ExpressionNegate>(std::move(stack.rbegin()[0])));
                 stack.pop_back();
             }
@@ -1707,14 +1707,13 @@ NonlinearExpressionPtr ModelingSystemGAMS::parseGamsInstructions(int codelen, /*
 
             if(child1IsProd && child0IsProd) // Add children of last element on stack to the previous element's children
             {
-                std::dynamic_pointer_cast<ExpressionProduct>(stack.rbegin()[1])
-                    ->children.add(
-                        std::move(std::dynamic_pointer_cast<ExpressionProduct>(stack.rbegin()[0])->children));
+                std::static_pointer_cast<ExpressionProduct>(stack.rbegin()[1])
+                    ->children.add(std::move(std::static_pointer_cast<ExpressionProduct>(stack.rbegin()[0])->children));
                 stack.pop_back();
             }
             else if(child1IsProd) // Add last element on stack to the previous element's children
             {
-                std::dynamic_pointer_cast<ExpressionProduct>(stack.rbegin()[1])
+                std::static_pointer_cast<ExpressionProduct>(stack.rbegin()[1])
                     ->children.add(std::move(stack.rbegin()[0]));
                 stack.pop_back();
             }
@@ -1722,7 +1721,7 @@ NonlinearExpressionPtr ModelingSystemGAMS::parseGamsInstructions(int codelen, /*
                                   // remove the last two from stack and readd the correct one
             {
                 auto tmpElement = stack.rbegin()[0];
-                std::dynamic_pointer_cast<ExpressionProduct>(tmpElement)->children.add(std::move(stack.rbegin()[1]));
+                std::static_pointer_cast<ExpressionProduct>(tmpElement)->children.add(std::move(stack.rbegin()[1]));
                 stack.pop_back();
                 stack.pop_back();
                 stack.push_back(tmpElement);
@@ -1752,7 +1751,7 @@ NonlinearExpressionPtr ModelingSystemGAMS::parseGamsInstructions(int codelen, /*
             {
                 if(mainIsProd)
                 {
-                    std::dynamic_pointer_cast<ExpressionProduct>(stack.rbegin()[0])
+                    std::static_pointer_cast<ExpressionProduct>(stack.rbegin()[0])
                         ->children.add(std::make_shared<ExpressionConstant>(variable->lowerBound));
                 }
                 else
@@ -1767,7 +1766,7 @@ NonlinearExpressionPtr ModelingSystemGAMS::parseGamsInstructions(int codelen, /*
             {
                 if(mainIsProd)
                 {
-                    std::dynamic_pointer_cast<ExpressionProduct>(stack.rbegin()[0])
+                    std::static_pointer_cast<ExpressionProduct>(stack.rbegin()[0])
                         ->children.add(std::make_shared<ExpressionVariable>(variable));
                 }
                 else
@@ -1788,7 +1787,7 @@ NonlinearExpressionPtr ModelingSystemGAMS::parseGamsInstructions(int codelen, /*
 
             if(mainIsProd)
             {
-                std::dynamic_pointer_cast<ExpressionProduct>(std::move(stack.rbegin()[0]))
+                std::static_pointer_cast<ExpressionProduct>(std::move(stack.rbegin()[0]))
                     ->children.add(std::make_shared<ExpressionConstant>(constants[address]));
             }
             else


### PR DESCRIPTION
Improvements to conversion of GAMS -> SHOT models: Simplification of sums of sums and products of products so they are combined into one sum/products; this fixes some crashes on large instances (e.g. autocorr*). 