### PR TITLE
fix two warnings from clang

### DIFF
--- a/src/MIPSolver/MIPSolverCbc.h
+++ b/src/MIPSolver/MIPSolverCbc.h
@@ -40,7 +40,7 @@ public:
         return *this;
     }
 
-    virtual CoinMessageHandler* clone() { return new CbcMessageHandler(*this); }
+    virtual CoinMessageHandler* clone() const { return new CbcMessageHandler(*this); }
 
     virtual int print();
 };

--- a/src/Model/Problem.cpp
+++ b/src/Model/Problem.cpp
@@ -2602,10 +2602,10 @@ ProblemPtr Problem::createCopy(
         // Copy nonlinear expression to objective
         if(this->objectiveFunction->properties.hasNonlinearExpression)
             std::dynamic_pointer_cast<NonlinearObjectiveFunction>(destinationObjective)
-                ->add(std::move(copyNonlinearExpression(
+                ->add(copyNonlinearExpression(
                     std::dynamic_pointer_cast<NonlinearObjectiveFunction>(this->objectiveFunction)
                         ->nonlinearExpression.get(),
-                    destinationProblem)));
+                    destinationProblem));
     }
 
     destinationProblem->add(std::move(destinationObjective));


### PR DESCRIPTION
1. The `clone()` method of a `CoinMessageHandler` is const. To overwrite it properly, make also SHOT's variant `const`.
2. There is a `std::move` which apparently is useless, but generates a warning:
```
Problem.cpp:2605:23: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
                ->add(std::move(copyNonlinearExpression(
                      ^
Problem.cpp:2605:23: note: remove std::move call here
                ->add(std::move(copyNonlinearExpression(
                      ^~~~~~~~~~
```
(https://stackoverflow.com/questions/70752203/stdmove-versus-copy-elision)