### PR TITLE
cleanup MC++ includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,8 +337,8 @@ include_directories(SYSTEM "${BOOST_DIR}")
 include_directories(SYSTEM "${CPPAD_DIR}/include/")
 include_directories(SYSTEM "${EIGEN_DIR}")
 include_directories(SYSTEM "${MCPP_DIR}/include")
-include_directories(SYSTEM "${MCPP_DIR}/3rdparty/cpplapack/include")
-include_directories(SYSTEM "${MCPP_DIR}/3rdparty/fadbad++")
+#include_directories(SYSTEM "${MCPP_DIR}/3rdparty/cpplapack/include")
+#include_directories(SYSTEM "${MCPP_DIR}/3rdparty/fadbad++")
 include_directories(SYSTEM "${SPDLOG_DIR}/include")
 
 # Make sure the source file lists are in the correct format

--- a/src/Model/NonlinearExpressions.h
+++ b/src/Model/NonlinearExpressions.h
@@ -17,7 +17,6 @@
 
 #include "../Utilities.h"
 
-#include "ffunc.hpp"
 #include "cppad/cppad.hpp"
 
 #include <memory>

--- a/src/Model/Terms.h
+++ b/src/Model/Terms.h
@@ -16,8 +16,6 @@
 
 #include "Variables.h"
 
-#include "ffunc.hpp"
-
 #include <Eigen/Eigenvalues>
 #include <vector>
 

--- a/src/Model/Variables.cpp
+++ b/src/Model/Variables.cpp
@@ -11,8 +11,6 @@
 #include "Variables.h"
 #include "Problem.h"
 
-#include "ffunc.hpp"
-
 #include "spdlog/fmt/fmt.h"
 
 #include "../Environment.h"

--- a/src/Model/Variables.h
+++ b/src/Model/Variables.h
@@ -18,7 +18,7 @@
 #include <ostream>
 #include <string>
 
-#include "ffunc.hpp"
+#include "interval.hpp"
 #include "cppad/cppad.hpp"
 
 namespace SHOT

--- a/src/Results.cpp
+++ b/src/Results.cpp
@@ -1082,7 +1082,7 @@ int Results::getNumberOfIterations() { return (iterations.size()); }
 
 double Results::getPrimalBound()
 {
-    if(!isnan(this->currentPrimalBound))
+    if(!std::isnan(this->currentPrimalBound))
         return (this->currentPrimalBound);
     else if(env->problem->objectiveFunction->direction == E_ObjectiveFunctionDirection::Minimize)
         return (SHOT_DBL_MAX);


### PR DESCRIPTION
Removes unnecessary includes of ffunc.hpp. Include interval.hpp instead.
This way, fadbad++ and cpplapack headers are no longer included (and could be removed).