### PR TITLE
remove use of GAMSMAJOR and GAMSMINOR in solver description

### DIFF
--- a/src/NLPSolver/NLPSolverGAMS.cpp
+++ b/src/NLPSolver/NLPSolverGAMS.cpp
@@ -319,7 +319,7 @@ void NLPSolverGAMS::updateVariableUpperBound(int variableIndex, double bound)
 
 std::string NLPSolverGAMS::getSolverDescription()
 {
-    std::string description = fmt::format("{} in GAMS {}.{}", selectedNLPSolver, GAMSMAJOR, GAMSMINOR);
+    std::string description = fmt::format("{} in GAMS", selectedNLPSolver);
 
     return (description);
 };


### PR DESCRIPTION
GAMS 44 deprecates the use of the GAMS version info from `gclgmc.h`: https://distdocs.gams.com/44/docs/RN_44.html#g4400_CAPI. (The file will be maintained in a separate project in the future.).

This PR removes the use of `GAMSMAJOR` and `GAMSMINOR` in SHOT.