### PR TITLE
fix copying of CBC message handler

### DIFF
--- a/src/MIPSolver/MIPSolverCbc.h
+++ b/src/MIPSolver/MIPSolverCbc.h
@@ -32,11 +32,12 @@ private:
 public:
     CbcMessageHandler(EnvironmentPtr envPtr) : CoinMessageHandler() { env = envPtr; }
 
-    CbcMessageHandler(const CbcMessageHandler& r) : CoinMessageHandler(r) { }
+    CbcMessageHandler(const CbcMessageHandler& r) : CoinMessageHandler(r), env(r.env) { }
 
     CbcMessageHandler& operator=(const CbcMessageHandler& r)
     {
         CoinMessageHandler::operator=(r);
+        env = r.env;
         return *this;
     }
 


### PR DESCRIPTION
Pointer to environment was not copied, which is problematic when running CBC multithreaded.