### PR TITLE
CI/CD Workflow update

### DIFF
--- a/.github/workflows/benchmarker.yml
+++ b/.github/workflows/benchmarker.yml
@@ -153,7 +153,7 @@ jobs:
         run: python main.py -c -s --runs 5
 
       - name: Upload benchmarks
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: benchmarks-${{ github.sha }}
           path: ${{ github.workspace }}/shot-benchmarker/benchmarks

--- a/.github/workflows/benchmarker.yml
+++ b/.github/workflows/benchmarker.yml
@@ -106,9 +106,9 @@ jobs:
           INPUT_BENCHMARK_TYPE: ${{ inputs.benchmark_type }}
           INPUT_BENCHMARKS: ${{ inputs.benchmarks  }}
           INPUT_SHOT_EXECUTABLE: ${{ inputs.shot_executable }}
-          OS_AUTH_URL: '${{ secrets.OS_AUTH_URL }}'
-          OS_PROJECT_ID: '${{ secrets.OS_PROJECT_ID }}'
-          OS_PROJECT_NAME: '${{ secrets.OS_PROJECT_NAME }}'
+          OS_AUTH_URL: 'https://pouta.csc.fi:5001/v3'
+          OS_PROJECT_ID: '230dabcfb234424cb77e7de501ef7efc'
+          OS_PROJECT_NAME: 'project_2001223'
           OS_USER_DOMAIN_NAME: "Default"
           OS_PROJECT_DOMAIN_ID: "default"
           OS_USERNAME: '${{ secrets.OS_USERNAME }}'

--- a/.github/workflows/benchmarker.yml
+++ b/.github/workflows/benchmarker.yml
@@ -20,7 +20,7 @@ on:
         type: string
       benchmarks:
         description: 'The benchmarks to run, can be a list of benchmarks or a single benchmark, defaults to all benchmarks'
-        default: ""
+        default: "all"
         required: false
         type: string
 
@@ -43,6 +43,9 @@ jobs:
       - shell: bash
         run: pip install -r requirements.txt
         working-directory: ${{ github.workspace }}/shot-benchmarker
+
+      - shell: bash
+        run: echo ${{ inputs.shot_executable }}
 
       - shell: bash
         env:

--- a/.github/workflows/benchmarker.yml
+++ b/.github/workflows/benchmarker.yml
@@ -115,8 +115,8 @@ jobs:
           OS_PROJECT_NAME: 'project_2001223'
           OS_USER_DOMAIN_NAME: "Default"
           OS_PROJECT_DOMAIN_ID: "default"
-          OS_USERNAME: ${{ secrets.OS_USERNAME }}
-          OS_PASSWORD: ${{ secrets.OS_PASSWORD }}
+          OS_USERNAME: '${{ secrets.OS_USERNAME }}'
+          OS_PASSWORD: '${{ secrets.OS_PASSWORD }}'
           OS_REGION_NAME: "regionOne"
           OS_INTERFACE: "public"
           OS_IDENTITY_API_VERSION: "3"

--- a/.github/workflows/benchmarker.yml
+++ b/.github/workflows/benchmarker.yml
@@ -106,8 +106,17 @@ jobs:
           INPUT_BENCHMARK_TYPE: ${{ inputs.benchmark_type }}
           INPUT_BENCHMARKS: ${{ inputs.benchmarks  }}
           INPUT_SHOT_EXECUTABLE: ${{ inputs.shot_executable }}
+          OS_PROJECT_ID: ${{ secrets.OS_PROJECT_ID }}
+          OS_PROJECT_NAME: ${{ secrets.OS_PROJECT_NAME }}
+          OS_USER_DOMAIN_NAME: "Default"
+          OS_PROJECT_DOMAIN_ID: "default"
+          OS_USERNAME: ${{ secrets.OS_USERNAME }}
+          OS_PASSWORD: ${{ secrets.OS_PASSWORD }}
+          OS_REGION_NAME: "regionOne"
+          OS_INTERFACE: "public"
+          OS_IDENTITY_API_VERSION: "3"
         working-directory: ${{ github.workspace }}/shot-benchmarker
-        run: python main.py
+        run: python main.py -c -s
 
       - name: Upload benchmarks
         uses: actions/upload-artifact@v3

--- a/.github/workflows/benchmarker.yml
+++ b/.github/workflows/benchmarker.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       shot_executable:
         description: 'The SHOT executable to run'
-        default: ${{ env.GITHUB_WORKSPACE }}/build/SHOT
+        default: ${{ github.workspace }}/build/SHOT
         required: false
         type: string
       benchmark_folder:

--- a/.github/workflows/benchmarker.yml
+++ b/.github/workflows/benchmarker.yml
@@ -3,9 +3,9 @@ name: Benchmark
 on:
   workflow_call:
     inputs:
-      shot_executable:
-        description: 'The SHOT executable to run'
-        default: ./SHOT
+      shot_executable_path:
+        description: 'The path to the SHOT executable to run'
+        default: "/SHOT"
         required: false
         type: string
       benchmark_folder:
@@ -86,10 +86,20 @@ jobs:
           name: ${{ inputs.shot_artifact }}
           path: ${{ github.workspace }}/shot-benchmarker
 
+      - name: Set the SHOT executable path if an artifact is used
+        if : ${{ inputs.shot_executable_path == '' }}
+        shell: bash
+        run: echo "SHOT_EXECUTABLE_PATH=${{ github.workspace }}/shot-benchmarker" >> $GITHUB_ENV
+
+      - name: Set the SHOT executable path
+        if: ${{ inputs.shot_executable_path != '' }}
+        shell: bash
+        run: echo "SHOT_EXECUTABLE_PATH=${{ inputs.shot_executable_path }}" >> $GITHUB_ENV
+
       - name: Make SHOT executable
         shell: bash
         run: |
-          cd ${{ github.workspace }}/shot-benchmarker
+          cd ${{ env.SHOT_EXECUTABLE_PATH }}
           chmod +x SHOT
 
       - name: Show linked libraries
@@ -125,7 +135,7 @@ jobs:
           INPUT_BENCHMARK_FOLDER: ${{ inputs.benchmark_folder }}
           INPUT_BENCHMARK_TYPE: ${{ inputs.benchmark_type }}
           INPUT_BENCHMARKS: ${{ inputs.benchmarks  }}
-          INPUT_SHOT_EXECUTABLE: ${{ inputs.shot_executable }}
+          INPUT_SHOT_EXECUTABLE: ${{ env.SHOT_EXECUTABLE_PATH }}/SHOT
           INPUT_IS_GAMS: ${{ inputs.enable_gams }}
           INPUT_IS_GUROBI: ${{ inputs.enable_gurobi }}
           OS_AUTH_URL: 'https://pouta.csc.fi:5001/v3'

--- a/.github/workflows/benchmarker.yml
+++ b/.github/workflows/benchmarker.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       shot_executable:
         description: 'The SHOT executable to run'
-        default: ${{ github.workspace }}/build/SHOT
+        default: ./../build/SHOT
         required: false
         type: string
       benchmark_folder:

--- a/.github/workflows/benchmarker.yml
+++ b/.github/workflows/benchmarker.yml
@@ -48,6 +48,11 @@ on:
         default: ""
         required: false
         type: string
+      artifact_suffix:
+        description: 'The suffix to add to the artifact name'
+        default: ''
+        required: false
+        type: string
     secrets:
       gurobi_license:
         description: 'Gurobi license file secret'
@@ -166,7 +171,7 @@ jobs:
       - name: Upload benchmarks
         uses: actions/upload-artifact@v4
         with:
-          name: benchmarks-${{ github.sha }}
+          name: benchmarks-${{ github.sha }}${{ inputs.artifact_suffix }}
           path: ${{ github.workspace }}/shot-benchmarker/benchmarks
 
       - name: Cleanup license files

--- a/.github/workflows/benchmarker.yml
+++ b/.github/workflows/benchmarker.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           python-version: 3.11
           cache: 'pip'
-        working-directory: ${{ github.workspace }}/shot-benchmarker
+          working-directory: ${{ github.workspace }}/shot-benchmarker
 
       - shell: bash
         run: pip install -r requirements.txt
@@ -50,5 +50,5 @@ jobs:
           INPUT_BENCHMARK_TYPE: ${{ inputs.benchmark_type }}
           INPUT_BENCHMARKS: ${{ inputs.benchmarks  }}
           INPUT_SHOT_EXECUTABLE: ${{ inputs.shot_executable }}
+          working-directory: ${{ github.workspace }}/shot-benchmarker
         run: python main.py
-        working-directory: ${{ github.workspace }}/shot-benchmarker

--- a/.github/workflows/benchmarker.yml
+++ b/.github/workflows/benchmarker.yml
@@ -23,11 +23,34 @@ on:
         default: "all"
         required: false
         type: string
+      enable_gurobi:
+        description: 'Is this a Gurobi build (this will install Gurobi)'
+        default: false
+        required: false
+        type: boolean
+      enable_gams:
+        description: 'Is this a GAMS build (this will install GAMS)'
+        default: false
+        required: false
+        type: boolean
+
+    secrets:
+      gurobi_license:
+        description: 'Gurobi license file secret'
+        required: false
+      gams_license:
+        description: 'GAMS license file secret'
+        required: false
 
     outputs:
       benchmarks:
         description: 'The benchmarks that were run'
         value: ${{ jobs.benchmark.outputs.benchmarks }}
+
+
+env:
+  GRB_LICENSE_FILE: ${{ github.workspace }}/gurobi.lic
+  GAMS_LICENSE_FILE: ${{ github.workspace }}/ThirdParty/gams42.3_linux_x64_64_sfx/gamslice.txt
 
 jobs:
   benchmark:
@@ -52,6 +75,19 @@ jobs:
 
       - shell: bash
         run: echo ${{ inputs.shot_executable }}
+
+      # Add the license file to the GAMS installation directory
+      - name: Setup GAMS License file
+        if: ${{ inputs.enable_gams }}
+        shell: bash
+        working-directory: ${{github.workspace}}
+        run: echo ${{ secrets.gams_license }} | base64 -d > $GAMS_LICENSE_FILE
+
+      - name: Setup Gurobi License file
+        if: ${{ inputs.enable_gurobi }}
+        shell: bash
+        working-directory: ${{github.workspace}}
+        run: echo ${{ secrets.gurobi_license }} | base64 -d > $GRB_LICENSE_FILE
 
       - shell: bash
         id: benchmark

--- a/.github/workflows/benchmarker.yml
+++ b/.github/workflows/benchmarker.yml
@@ -104,3 +104,10 @@ jobs:
         with:
           name: benchmarks-${{ github.sha }}
           path: ${{ github.workspace }}/shot-benchmarker/benchmarks
+
+      - name: Cleanup license files
+        if: ${{ success() || failure() }}
+        shell: bash
+        run: |
+          rm -f $GRB_LICENSE_FILE
+          rm -f $GAMS_LICENSE_FILE

--- a/.github/workflows/benchmarker.yml
+++ b/.github/workflows/benchmarker.yml
@@ -31,8 +31,7 @@ jobs:
 
     steps:
       - shell: bash
-        run: git clone https://github.com/maxemiliang/shot-benchmarker.git
-
+        run: git pull -C shot-benchmarker || git clone https://github.com/maxemiliang/shot-benchmarker.git
 
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/benchmarker.yml
+++ b/.github/workflows/benchmarker.yml
@@ -92,6 +92,11 @@ jobs:
           cd ${{ github.workspace }}/shot-benchmarker
           chmod +x SHOT
 
+      - name: Show linked libraries
+        shell: bash
+        working-directory: ${{ github.workspace }}/shot-benchmarker
+        run: ldd SHOT
+
       - uses: actions/setup-python@v4
         with:
           python-version: 3.11

--- a/.github/workflows/benchmarker.yml
+++ b/.github/workflows/benchmarker.yml
@@ -78,7 +78,6 @@ jobs:
         with:
           python-version: 3.11
           cache: 'pip'
-          working-directory: ${{ github.workspace }}/shot-benchmarker
 
       - shell: bash
         run: pip install -r requirements.txt
@@ -91,13 +90,13 @@ jobs:
       - name: Setup GAMS License file
         if: ${{ inputs.enable_gams }}
         shell: bash
-        working-directory: ${{github.workspace}}
+        working-directory: ${{ github.workspace }}
         run: echo ${{ secrets.gams_license }} | base64 -d > $GAMS_LICENSE_FILE
 
       - name: Setup Gurobi License file
         if: ${{ inputs.enable_gurobi }}
         shell: bash
-        working-directory: ${{github.workspace}}
+        working-directory: ${{ github.workspace }}
         run: echo ${{ secrets.gurobi_license }} | base64 -d > $GRB_LICENSE_FILE
 
       - shell: bash

--- a/.github/workflows/benchmarker.yml
+++ b/.github/workflows/benchmarker.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       shot_executable:
         description: 'The SHOT executable to run'
-        default: "shot"
+        default: ${{ github.workspace }}/build/SHOT
         required: false
         type: string
       benchmark_folder:

--- a/.github/workflows/benchmarker.yml
+++ b/.github/workflows/benchmarker.yml
@@ -152,6 +152,7 @@ jobs:
           INPUT_BENCHMARK_TYPE: ${{ inputs.benchmark_type }}
           INPUT_BENCHMARKS: ${{ inputs.benchmarks  }}
           INPUT_SHOT_EXECUTABLE: ${{ env.SHOT_EXECUTABLE_PATH }}/SHOT
+          INPUT_COMPARISON_SUFFIX: ${{ inputs.artifact_suffix }}
           INPUT_IS_GAMS: ${{ inputs.enable_gams }}
           INPUT_IS_GUROBI: ${{ inputs.enable_gurobi }}
           OS_AUTH_URL: 'https://pouta.csc.fi:5001/v3'

--- a/.github/workflows/benchmarker.yml
+++ b/.github/workflows/benchmarker.yml
@@ -62,3 +62,9 @@ jobs:
           INPUT_SHOT_EXECUTABLE: ${{ inputs.shot_executable }}
         working-directory: ${{ github.workspace }}/shot-benchmarker
         run: python main.py
+
+      - name: Upload benchmarks
+        uses: actions/upload-artifact@v3
+        with:
+          name: benchmarks-${{ github.sha }}
+          path: ${{ github.workspace }}/shot-benchmarker/benchmarks

--- a/.github/workflows/benchmarker.yml
+++ b/.github/workflows/benchmarker.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       shot_executable:
         description: 'The SHOT executable to run'
-        default: ./../build/SHOT
+        default: ./../shot-binary/SHOT
         required: false
         type: string
       benchmark_folder:
@@ -76,7 +76,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: ${{ inputs.shot_artifact }}
-          path: ${{ github.workspace }}/build
+          path: ${{ github.workspace }}/shot-binary
 
       - shell: bash
         run: git -C shot-benchmarker pull || git clone https://github.com/maxemiliang/shot-benchmarker.git

--- a/.github/workflows/benchmarker.yml
+++ b/.github/workflows/benchmarker.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       shot_executable:
         description: 'The SHOT executable to run'
-        default: ./../shot-binary/SHOT
+        default: ./SHOT
         required: false
         type: string
       benchmark_folder:
@@ -71,15 +71,21 @@ jobs:
     runs-on: [ self-hosted, linux, cmake ]
 
     steps:
+      - shell: bash
+        run: git -C shot-benchmarker pull || git clone https://github.com/maxemiliang/shot-benchmarker.git
+
       - name: Fetch SHOT artifact
         if: ${{ inputs.shot_artifact != '' }}
         uses: actions/download-artifact@v3
         with:
           name: ${{ inputs.shot_artifact }}
-          path: ${{ github.workspace }}/shot-binary
+          path: ${{ github.workspace }}/shot-benchmarker
 
-      - shell: bash
-        run: git -C shot-benchmarker pull || git clone https://github.com/maxemiliang/shot-benchmarker.git
+      - name: Make SHOT executable
+        shell: bash
+        run: |
+          cd ${{ github.workspace }}/shot-benchmarker
+          chmod +x SHOT
 
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/benchmarker.yml
+++ b/.github/workflows/benchmarker.yml
@@ -1,0 +1,54 @@
+name: Benchmark
+
+on:
+  workflow_call:
+    inputs:
+      shot_executable:
+        description: 'The SHOT executable to run'
+        default: "shot"
+        required: false
+        type: string
+      benchmark_folder:
+        description: 'The benchmark to run (folder name from: https://github.com/andreaslundell/SHOT_benchmark_problems)'
+        default: "MINLP-convex-small"
+        required: false
+        type: string
+      benchmark_type:
+        description: 'The benchmark type to run, can be gms, nl or osil'
+        default: "nl"
+        required: false
+        type: string
+      benchmarks:
+        description: 'The benchmarks to run, can be a list of benchmarks or a single benchmark, defaults to all benchmarks'
+        default: ""
+        required: false
+        type: string
+
+jobs:
+  benchmark:
+    name: Benchmark SHOT
+    runs-on: [ self-hosted, linux, cmake ]
+
+    steps:
+      - shell: bash
+        run: git clone https://github.com/maxemiliang/shot-benchmarker.git
+
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+          cache: 'pip'
+        working-directory: ${{ github.workspace }}/shot-benchmarker
+
+      - shell: bash
+        run: pip install -r requirements.txt
+        working-directory: ${{ github.workspace }}/shot-benchmarker
+
+      - shell: bash
+        env:
+          INPUT_BENCHMARK_FOLDER: ${{ inputs.benchmark_folder }}
+          INPUT_BENCHMARK_TYPE: ${{ inputs.benchmark_type }}
+          INPUT_BENCHMARKS: ${{ inputs.benchmarks  }}
+          INPUT_SHOT_EXECUTABLE: ${{ inputs.shot_executable }}
+        run: python main.py
+        working-directory: ${{ github.workspace }}/shot-benchmarker

--- a/.github/workflows/benchmarker.yml
+++ b/.github/workflows/benchmarker.yml
@@ -116,6 +116,7 @@ jobs:
           OS_REGION_NAME: "regionOne"
           OS_INTERFACE: "public"
           OS_IDENTITY_API_VERSION: "3"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         working-directory: ${{ github.workspace }}/shot-benchmarker
         run: python main.py -c -s
 

--- a/.github/workflows/benchmarker.yml
+++ b/.github/workflows/benchmarker.yml
@@ -38,6 +38,16 @@ on:
         default: ""
         required: false
         type: string
+      gurobi_license_file:
+        description: 'The path to the Gurobi license file'
+        default: ""
+        required: false
+        type: string
+      gams_license_file:
+        description: 'The path to the GAMS license file'
+        default: ""
+        required: false
+        type: string
     secrets:
       gurobi_license:
         description: 'Gurobi license file secret'
@@ -60,8 +70,8 @@ on:
 
 
 env:
-  GRB_LICENSE_FILE: ${{ github.workspace }}/gurobi.lic
-  GAMS_LICENSE_FILE: ${{ github.workspace }}/ThirdParty/gams42.3_linux_x64_64_sfx/gamslice.txt
+  GRB_LICENSE_FILE: ${{inputs.gurobi_license_file}}
+  GAMS_LICENSE_FILE: ${{inputs.gams_license_file}}
 
 jobs:
   benchmark:

--- a/.github/workflows/benchmarker.yml
+++ b/.github/workflows/benchmarker.yml
@@ -124,7 +124,7 @@ jobs:
           OS_IDENTITY_API_VERSION: "3"
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         working-directory: ${{ github.workspace }}/shot-benchmarker
-        run: python main.py -c -s
+        run: python main.py -c -s --runs 5
 
       - name: Upload benchmarks
         uses: actions/upload-artifact@v3

--- a/.github/workflows/benchmarker.yml
+++ b/.github/workflows/benchmarker.yml
@@ -71,17 +71,12 @@ jobs:
     runs-on: [ self-hosted, linux, cmake ]
 
     steps:
-      - name: Cleanup workspace
-        run: |
-          sudo rm -rf ./* || true
-          sudo rm -rf ./.??* || true  
-
       - shell: bash
         run: git -C shot-benchmarker pull || git clone https://github.com/maxemiliang/shot-benchmarker.git
 
       - name: Fetch SHOT artifact
         if: ${{ inputs.shot_artifact != '' }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.shot_artifact }}
           path: ${{ github.workspace }}/shot-benchmarker
@@ -91,10 +86,16 @@ jobs:
         shell: bash
         run: echo "SHOT_EXECUTABLE_PATH=${{ github.workspace }}/shot-benchmarker" >> $GITHUB_ENV
 
-      - name: Set the SHOT executable path
+      # If the path is not an absolute path, we assume it is relative to the current working directory
+      - name: Set the SHOT executable path.
         if: ${{ inputs.shot_executable_path != '' }}
         shell: bash
-        run: echo "SHOT_EXECUTABLE_PATH=${{ inputs.shot_executable_path }}" >> $GITHUB_ENV
+        run: |
+          if [[ ${{ inputs.shot_executable_path }} == /* ]]; then
+            echo "SHOT_EXECUTABLE_PATH=${{ inputs.shot_executable_path }}" >> $GITHUB_ENV
+          else
+            echo "SHOT_EXECUTABLE_PATH=${{ github.workspace }}/${{ inputs.shot_executable_path }}" >> $GITHUB_ENV
+          fi
 
       - name: Make SHOT executable
         shell: bash
@@ -104,7 +105,7 @@ jobs:
 
       - name: Show linked libraries
         shell: bash
-        working-directory: ${{ github.workspace }}/shot-benchmarker
+        working-directory: ${{ env.SHOT_EXECUTABLE_PATH }}
         run: ldd SHOT
 
       - uses: actions/setup-python@v4

--- a/.github/workflows/benchmarker.yml
+++ b/.github/workflows/benchmarker.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       shot_executable:
         description: 'The SHOT executable to run'
-        default: ${{ github.workspace }}/build/SHOT
+        default: ${{ env.GITHUB_WORKSPACE }}/build/SHOT
         required: false
         type: string
       benchmark_folder:

--- a/.github/workflows/benchmarker.yml
+++ b/.github/workflows/benchmarker.yml
@@ -71,6 +71,11 @@ jobs:
     runs-on: [ self-hosted, linux, cmake ]
 
     steps:
+      - name: Cleanup workspace
+        run: |
+          sudo rm -rf ./* || true
+          sudo rm -rf ./.??* || true  
+
       - shell: bash
         run: git -C shot-benchmarker pull || git clone https://github.com/maxemiliang/shot-benchmarker.git
 

--- a/.github/workflows/benchmarker.yml
+++ b/.github/workflows/benchmarker.yml
@@ -33,7 +33,11 @@ on:
         default: false
         required: false
         type: boolean
-
+      shot_artifact:
+        description: 'The SHOT artifact to use'
+        default: ""
+        required: false
+        type: string
     secrets:
       gurobi_license:
         description: 'Gurobi license file secret'
@@ -60,6 +64,13 @@ jobs:
     runs-on: [ self-hosted, linux, cmake ]
 
     steps:
+      - name: Fetch SHOT artifact
+        if: ${{ inputs.shot_artifact != '' }}
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.shot_artifact }}
+          path: ${{ github.workspace }}/build
+
       - shell: bash
         run: git -C shot-benchmarker pull || git clone https://github.com/maxemiliang/shot-benchmarker.git
 

--- a/.github/workflows/benchmarker.yml
+++ b/.github/workflows/benchmarker.yml
@@ -106,6 +106,7 @@ jobs:
           INPUT_BENCHMARK_TYPE: ${{ inputs.benchmark_type }}
           INPUT_BENCHMARKS: ${{ inputs.benchmarks  }}
           INPUT_SHOT_EXECUTABLE: ${{ inputs.shot_executable }}
+          OS_AUTH_URL: ${{ secrets.OS_AUTH_URL }}
           OS_PROJECT_ID: ${{ secrets.OS_PROJECT_ID }}
           OS_PROJECT_NAME: ${{ secrets.OS_PROJECT_NAME }}
           OS_USER_DOMAIN_NAME: "Default"

--- a/.github/workflows/benchmarker.yml
+++ b/.github/workflows/benchmarker.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - shell: bash
-        run: git pull -C shot-benchmarker || git clone https://github.com/maxemiliang/shot-benchmarker.git
+        run: git -C shot-benchmarker pull || git clone https://github.com/maxemiliang/shot-benchmarker.git
 
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/benchmarker.yml
+++ b/.github/workflows/benchmarker.yml
@@ -24,8 +24,15 @@ on:
         required: false
         type: string
 
+    outputs:
+      benchmarks:
+        description: 'The benchmarks that were run'
+        value: ${{ jobs.benchmark.outputs.benchmarks }}
+
 jobs:
   benchmark:
+    outputs:
+        benchmarks: ${{ steps.benchmark.outputs.benchmarks }}
     name: Benchmark SHOT
     runs-on: [ self-hosted, linux, cmake ]
 
@@ -47,6 +54,7 @@ jobs:
         run: echo ${{ inputs.shot_executable }}
 
       - shell: bash
+        id: benchmark
         env:
           INPUT_BENCHMARK_FOLDER: ${{ inputs.benchmark_folder }}
           INPUT_BENCHMARK_TYPE: ${{ inputs.benchmark_type }}

--- a/.github/workflows/benchmarker.yml
+++ b/.github/workflows/benchmarker.yml
@@ -106,17 +106,17 @@ jobs:
           INPUT_BENCHMARK_TYPE: ${{ inputs.benchmark_type }}
           INPUT_BENCHMARKS: ${{ inputs.benchmarks  }}
           INPUT_SHOT_EXECUTABLE: ${{ inputs.shot_executable }}
-          OS_AUTH_URL: ${{ secrets.OS_AUTH_URL }}
-          OS_PROJECT_ID: ${{ secrets.OS_PROJECT_ID }}
-          OS_PROJECT_NAME: ${{ secrets.OS_PROJECT_NAME }}
+          OS_AUTH_URL: '${{ secrets.OS_AUTH_URL }}'
+          OS_PROJECT_ID: '${{ secrets.OS_PROJECT_ID }}'
+          OS_PROJECT_NAME: '${{ secrets.OS_PROJECT_NAME }}'
           OS_USER_DOMAIN_NAME: "Default"
           OS_PROJECT_DOMAIN_ID: "default"
-          OS_USERNAME: ${{ secrets.OS_USERNAME }}
-          OS_PASSWORD: ${{ secrets.OS_PASSWORD }}
+          OS_USERNAME: '${{ secrets.OS_USERNAME }}'
+          OS_PASSWORD: '${{ secrets.OS_PASSWORD }}'
           OS_REGION_NAME: "regionOne"
           OS_INTERFACE: "public"
           OS_IDENTITY_API_VERSION: "3"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         working-directory: ${{ github.workspace }}/shot-benchmarker
         run: python main.py -c -s
 

--- a/.github/workflows/benchmarker.yml
+++ b/.github/workflows/benchmarker.yml
@@ -83,9 +83,6 @@ jobs:
         run: pip install -r requirements.txt
         working-directory: ${{ github.workspace }}/shot-benchmarker
 
-      - shell: bash
-        run: echo ${{ inputs.shot_executable }}
-
       # Add the license file to the GAMS installation directory
       - name: Setup GAMS License file
         if: ${{ inputs.enable_gams }}
@@ -111,8 +108,8 @@ jobs:
           OS_PROJECT_NAME: 'project_2001223'
           OS_USER_DOMAIN_NAME: "Default"
           OS_PROJECT_DOMAIN_ID: "default"
-          OS_USERNAME: '${{ secrets.OS_USERNAME }}'
-          OS_PASSWORD: '${{ secrets.OS_PASSWORD }}'
+          OS_USERNAME: ${{ secrets.OS_USERNAME }}
+          OS_PASSWORD: ${{ secrets.OS_PASSWORD }}
           OS_REGION_NAME: "regionOne"
           OS_INTERFACE: "public"
           OS_IDENTITY_API_VERSION: "3"

--- a/.github/workflows/benchmarker.yml
+++ b/.github/workflows/benchmarker.yml
@@ -45,6 +45,13 @@ on:
       gams_license:
         description: 'GAMS license file secret'
         required: false
+      OS_USERNAME:
+        description: 'OpenStack username'
+        required: true
+      OS_PASSWORD:
+        description: 'OpenStack password'
+        required: true
+
 
     outputs:
       benchmarks:

--- a/.github/workflows/benchmarker.yml
+++ b/.github/workflows/benchmarker.yml
@@ -50,5 +50,5 @@ jobs:
           INPUT_BENCHMARK_TYPE: ${{ inputs.benchmark_type }}
           INPUT_BENCHMARKS: ${{ inputs.benchmarks  }}
           INPUT_SHOT_EXECUTABLE: ${{ inputs.shot_executable }}
-          working-directory: ${{ github.workspace }}/shot-benchmarker
+        working-directory: ${{ github.workspace }}/shot-benchmarker
         run: python main.py

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -37,7 +37,7 @@ jobs:
   # Finally, we run some simple benchmarks
   benchmark:
     name: Benchmark
-    needs: [ build-test, build-proprietary ]
+    needs: [ build-test ]
     uses: ./.github/workflows/benchmarker.yml
     with:
       benchmark_folder: "MINLP-convex-small"
@@ -52,7 +52,7 @@ jobs:
   # Publish the test results as an output
   publish-test:
     name: Publish test results
-    needs: [ build-test, build-proprietary ]
+    needs: [ build-test ]
     runs-on: [ self-hosted, docker ]
     steps:
       - uses: actions/download-artifact@v3

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -42,7 +42,7 @@ jobs:
     with:
       benchmark_folder: "MINLP-convex-small"
       benchmark_type: "nl"
-      shot_executable: ${{github.workspace}}/build/SHOT
+      shot_executable: ${{ github.workspace }}/build/SHOT
 
   # Publish the test results as an output
   publish-test:

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -18,26 +18,26 @@ jobs:
       upload_artifacts: true
 
   # Then, we build and test using all licenses included proprietary ones
-#  build-proprietary:
-#    name: Build & Test (Proprietary licenses)
-#    needs: [ build-test ]
-#    uses: ./.github/workflows/build-workflow.yml
-#    with:
-#      job_count: 4
-#      build_type: Release
-#      retention: 30
-#      upload_artifacts: false
-#      enable_gurobi: true
-#      enable_gams: true
-#      artifact_suffix: '-proprietary'
-#    secrets:
-#      gurobi_license: ${{ secrets.GUROBI_LICENSE_FILE }}
-#      gams_license: ${{ secrets.GAMS_LICENSE_FILE }}
+  build-proprietary:
+    name: Build & Test (Proprietary licenses)
+    needs: [ build-test ]
+    uses: ./.github/workflows/build-workflow.yml
+    with:
+      job_count: 4
+      build_type: Release
+      retention: 30
+      upload_artifacts: false
+      enable_gurobi: true
+      enable_gams: true
+      artifact_suffix: '-proprietary'
+    secrets:
+      gurobi_license: ${{ secrets.GUROBI_LICENSE_FILE }}
+      gams_license: ${{ secrets.GAMS_LICENSE_FILE }}
 
   # Finally, we run some simple benchmarks
   benchmark:
     name: Benchmark
-    needs: [ build-test ]
+    needs: [ build-test, build-proprietary ]
     uses: ./.github/workflows/benchmarker.yml
     with:
       benchmark_folder: "MINLP-convex-small"
@@ -51,21 +51,21 @@ jobs:
       OS_USERNAME: ${{ secrets.OS_USERNAME }}
       OS_PASSWORD: ${{ secrets.OS_PASSWORD }}
 
-  # Publish the test results as an output
-#  publish-test:
-#    name: Publish test results
-#    needs: [ build-test ]
-#    runs-on: [ self-hosted, docker ]
-#    steps:
-#      - uses: actions/download-artifact@v3
-#        name: Download artifacts
-#        with:
-#          path: artifacts
-#
-#      - name: Publish Test Results
-#        uses: EnricoMi/publish-unit-test-result-action@v2
-#        if: always()
-#        with:
-#          files: |
-#            artifacts/test-*/*.xml
+   # Publish the test results as an output
+  publish-test:
+    name: Publish test results
+    needs: [ build-test, build-proprietary, benchmark ]
+    runs-on: [ self-hosted, docker ]
+    steps:
+      - uses: actions/download-artifact@v3
+        name: Download artifacts
+        with:
+          path: artifacts
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: |
+            artifacts/test-*/*.xml
 

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -16,6 +16,10 @@ jobs:
       build_type: Release
       retention: 30
       upload_artifacts: true
+      run_benchmarks: true
+    secrets:
+      OS_USERNAME: ${{ secrets.OS_USERNAME }}
+      OS_PASSWORD: ${{ secrets.OS_PASSWORD }}
 
   # Then, we build and test using all licenses included proprietary ones
   build-proprietary:
@@ -33,6 +37,8 @@ jobs:
     secrets:
       gurobi_license: ${{ secrets.GUROBI_LICENSE_FILE }}
       gams_license: ${{ secrets.GAMS_LICENSE_FILE }}
+      OS_USERNAME: ${{ secrets.OS_USERNAME }}
+      OS_PASSWORD: ${{ secrets.OS_PASSWORD }}
 
 
   # Publish the test results as an output

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: [ self-hosted, docker ]
     steps:
     - name: Run Benchmark
-      uses: maxemiliang/shot-benchmarker@v1.6
+      uses: maxemiliang/shot-benchmarker@v1.7
       with:
         benchmark_folder: "MINLP-convex-small"
         benchmark_type: "nl"

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -38,7 +38,7 @@ jobs:
   benchmark:
     name: Benchmark
     needs: [ build-test ]
-    uses: ./.github/workflows/benchmarker.yml§
+    uses: ./.github/workflows/benchmarker.yml
     with:
       benchmark_folder: "MINLP-convex-small"
       benchmark_type: "nl"

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -34,6 +34,7 @@ jobs:
       enable_gurobi: true
       enable_gams: true
       artifact_suffix: '-proprietary'
+      run_benchmarks: true
     secrets:
       gurobi_license: ${{ secrets.GUROBI_LICENSE_FILE }}
       gams_license: ${{ secrets.GAMS_LICENSE_FILE }}

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: [ self-hosted, docker ]
     steps:
     - name: Run Benchmark
-      uses: maxemiliang/shot-benchmarker@v1.7
+      uses: maxemiliang/shot-benchmarker@v1.8
       with:
         benchmark_folder: "MINLP-convex-small"
         benchmark_type: "nl"

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -8,14 +8,14 @@ concurrency: push-build
 
 jobs:
   # First, we build and test using the default build options and only open source external libraries
-  build-test:
-    name: Build & Test
-    uses: ./.github/workflows/build-workflow.yml
-    with:
-      job_count: 4
-      build_type: Release
-      retention: 30
-      upload_artifacts: true
+#  build-test:
+#    name: Build & Test
+#    uses: ./.github/workflows/build-workflow.yml
+#    with:
+#      job_count: 4
+#      build_type: Release
+#      retention: 30
+#      upload_artifacts: true
 
   # Then, we build and test using all licenses included proprietary ones
 #  build-proprietary:
@@ -37,33 +37,33 @@ jobs:
   # Finally, we run some simple benchmarks
   benchmark:
     name: Benchmark
-    needs: [ build-test ]
+#    needs: [ build-test ]
     uses: ./.github/workflows/benchmarker.yml
     with:
       benchmark_folder: "MINLP-convex-small"
       benchmark_type: "nl"
       enable_gurobi: false
       enable_gams: false
-      shot_artifact: shot-binary-${{ github.sha }}
+      shot_artifact: shot-binary-b22eca247cc8986be66df8f7e5a9cbe6e55a1f70
     secrets:
       gurobi_license: ${{ secrets.GUROBI_LICENSE_FILE }}
       gams_license: ${{ secrets.GAMS_LICENSE_FILE }}
 
   # Publish the test results as an output
-  publish-test:
-    name: Publish test results
-    needs: [ build-test ]
-    runs-on: [ self-hosted, docker ]
-    steps:
-      - uses: actions/download-artifact@v3
-        name: Download artifacts
-        with:
-          path: artifacts
-
-      - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
-        if: always()
-        with:
-          files: |
-            artifacts/test-*/*.xml
+#  publish-test:
+#    name: Publish test results
+#    needs: [ build-test ]
+#    runs-on: [ self-hosted, docker ]
+#    steps:
+#      - uses: actions/download-artifact@v3
+#        name: Download artifacts
+#        with:
+#          path: artifacts
+#
+#      - name: Publish Test Results
+#        uses: EnricoMi/publish-unit-test-result-action@v2
+#        if: always()
+#        with:
+#          files: |
+#            artifacts/test-*/*.xml
 

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: [ self-hosted, docker ]
     steps:
     - name: Run Benchmark
-      uses: maxemiliang/shot-benchmarker@v1.5
+      uses: maxemiliang/shot-benchmarker@v1.6
       with:
         benchmark_folder: "MINLP-convex-small"
         benchmark_type: "nl"

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -16,8 +16,6 @@ jobs:
       build_type: Release
       retention: 30
       upload_artifacts: true
-    outputs:
-      binary-artifact: ${{ steps.build.output-artifacts.binary }}
 
 #  # Then, we build and test using all licenses included proprietary ones
 #  build-proprietary:

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -38,14 +38,11 @@ jobs:
   benchmark:
     name: Benchmark
     needs: [ build-test ]
-    runs-on: [ self-hosted, docker ]
-    steps:
-    - name: Run Benchmark
-      uses: maxemiliang/shot-benchmarker@v1.8
-      with:
-        benchmark_folder: "MINLP-convex-small"
-        benchmark_type: "nl"
-        shot_executable: ${{github.workspace}}/build/SHOT
+    uses: ./.github/workflows/benchmarker.yml§
+    with:
+      benchmark_folder: "MINLP-convex-small"
+      benchmark_type: "nl"
+      shot_executable: ${{github.workspace}}/build/SHOT
 
   # Publish the test results as an output
   publish-test:

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -48,6 +48,8 @@ jobs:
     secrets:
       gurobi_license: ${{ secrets.GUROBI_LICENSE_FILE }}
       gams_license: ${{ secrets.GAMS_LICENSE_FILE }}
+      OS_USERNAME: ${{ secrets.OS_USERNAME }}
+      OS_PASSWORD: ${{ secrets.OS_PASSWORD }}
 
   # Publish the test results as an output
 #  publish-test:

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -44,7 +44,7 @@ jobs:
       benchmark_type: "nl"
       enable_gurobi: false
       enable_gams: false
-      shot_artifact: ${{ needs.build-test.outputs.binary-artifact }}
+      shot_artifact: shot-binary-${{ github.sha }}
     secrets:
       gurobi_license: ${{ secrets.GUROBI_LICENSE_FILE }}
       gams_license: ${{ secrets.GAMS_LICENSE_FILE }}

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -38,7 +38,7 @@ jobs:
   # Publish the test results as an output
   publish-test:
     name: Publish test results
-    needs: [ build-test, build-proprietary, benchmark ]
+    needs: [ build-test, build-proprietary ]
     runs-on: [ self-hosted, docker ]
     steps:
       - uses: actions/download-artifact@v3

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -16,23 +16,25 @@ jobs:
       build_type: Release
       retention: 30
       upload_artifacts: true
+    outputs:
+      binary-artifact: ${{ steps.build.output-artifacts.binary }}
 
-  # Then, we build and test using all licenses included proprietary ones
-  build-proprietary:
-    name: Build & Test (Proprietary licenses)
-    needs: [ build-test ]
-    uses: ./.github/workflows/build-workflow.yml
-    with:
-      job_count: 4
-      build_type: Release
-      retention: 30
-      upload_artifacts: false
-      enable_gurobi: true
-      enable_gams: true
-      artifact_suffix: '-proprietary'
-    secrets:
-      gurobi_license: ${{ secrets.GUROBI_LICENSE_FILE }}
-      gams_license: ${{ secrets.GAMS_LICENSE_FILE }}
+#  # Then, we build and test using all licenses included proprietary ones
+#  build-proprietary:
+#    name: Build & Test (Proprietary licenses)
+#    needs: [ build-test ]
+#    uses: ./.github/workflows/build-workflow.yml
+#    with:
+#      job_count: 4
+#      build_type: Release
+#      retention: 30
+#      upload_artifacts: false
+#      enable_gurobi: true
+#      enable_gams: true
+#      artifact_suffix: '-proprietary'
+#    secrets:
+#      gurobi_license: ${{ secrets.GUROBI_LICENSE_FILE }}
+#      gams_license: ${{ secrets.GAMS_LICENSE_FILE }}
 
   # Finally, we run some simple benchmarks
   benchmark:

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -17,22 +17,22 @@ jobs:
       retention: 30
       upload_artifacts: true
 
-#  # Then, we build and test using all licenses included proprietary ones
-  build-proprietary:
-    name: Build & Test (Proprietary licenses)
-    needs: [ build-test ]
-    uses: ./.github/workflows/build-workflow.yml
-    with:
-      job_count: 4
-      build_type: Release
-      retention: 30
-      upload_artifacts: false
-      enable_gurobi: true
-      enable_gams: true
-      artifact_suffix: '-proprietary'
-    secrets:
-      gurobi_license: ${{ secrets.GUROBI_LICENSE_FILE }}
-      gams_license: ${{ secrets.GAMS_LICENSE_FILE }}
+  # Then, we build and test using all licenses included proprietary ones
+#  build-proprietary:
+#    name: Build & Test (Proprietary licenses)
+#    needs: [ build-test ]
+#    uses: ./.github/workflows/build-workflow.yml
+#    with:
+#      job_count: 4
+#      build_type: Release
+#      retention: 30
+#      upload_artifacts: false
+#      enable_gurobi: true
+#      enable_gams: true
+#      artifact_suffix: '-proprietary'
+#    secrets:
+#      gurobi_license: ${{ secrets.GUROBI_LICENSE_FILE }}
+#      gams_license: ${{ secrets.GAMS_LICENSE_FILE }}
 
   # Finally, we run some simple benchmarks
   benchmark:

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -8,56 +8,56 @@ concurrency: push-build
 
 jobs:
   # First, we build and test using the default build options and only open source external libraries
-#  build-test:
-#    name: Build & Test
-#    uses: ./.github/workflows/build-workflow.yml
-#    with:
-#      job_count: 4
-#      build_type: Release
-#      retention: 30
-#      upload_artifacts: true
+  build-test:
+    name: Build & Test
+    uses: ./.github/workflows/build-workflow.yml
+    with:
+      job_count: 4
+      build_type: Release
+      retention: 30
+      upload_artifacts: true
 
   # Then, we build and test using all licenses included proprietary ones
-#  build-proprietary:
-#    name: Build & Test (Proprietary licenses)
-#    needs: [ build-test ]
-#    uses: ./.github/workflows/build-workflow.yml
-#    with:
-#      job_count: 4
-#      build_type: Release
-#      retention: 30
-#      upload_artifacts: false
-#      enable_gurobi: true
-#      enable_gams: true
-#      artifact_suffix: '-proprietary'
-#    secrets:
-#      gurobi_license: ${{ secrets.GUROBI_LICENSE_FILE }}
-#      gams_license: ${{ secrets.GAMS_LICENSE_FILE }}
+  build-proprietary:
+    name: Build & Test (Proprietary licenses)
+    needs: [ build-test ]
+    uses: ./.github/workflows/build-workflow.yml
+    with:
+      job_count: 4
+      build_type: Release
+      retention: 30
+      upload_artifacts: false
+      enable_gurobi: true
+      enable_gams: true
+      artifact_suffix: '-proprietary'
+    secrets:
+      gurobi_license: ${{ secrets.GUROBI_LICENSE_FILE }}
+      gams_license: ${{ secrets.GAMS_LICENSE_FILE }}
 
   # Finally, we run some simple benchmarks
   benchmark:
     name: Benchmark
-#    needs: [ build-test ]
+    needs: [ build-test, build-proprietary ]
     uses: ./.github/workflows/benchmarker.yml
     with:
       benchmark_folder: "MINLP-convex-small"
       benchmark_type: "nl"
 
   # Publish the test results as an output
-#  publish-test:
-#    name: Publish test results
-#    needs: [ build-test ]
-#    runs-on: [ self-hosted, docker ]
-#    steps:
-#      - uses: actions/download-artifact@v3
-#        name: Download artifacts
-#        with:
-#          path: artifacts
-#
-#      - name: Publish Test Results
-#        uses: EnricoMi/publish-unit-test-result-action@v2
-#        if: always()
-#        with:
-#          files: |
-#            artifacts/test-*/*.xml
+  publish-test:
+    name: Publish test results
+    needs: [ build-test, build-proprietary ]
+    runs-on: [ self-hosted, docker ]
+    steps:
+      - uses: actions/download-artifact@v3
+        name: Download artifacts
+        with:
+          path: artifacts
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: |
+            artifacts/test-*/*.xml
 

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -42,8 +42,9 @@ jobs:
     with:
       benchmark_folder: "MINLP-convex-small"
       benchmark_type: "nl"
-      enable_gurobi: true
-      enable_gams: true
+      enable_gurobi: false
+      enable_gams: false
+      shot_artifact: ${{ needs.build-test.outputs.binary-artifact }}
     secrets:
       gurobi_license: ${{ secrets.GUROBI_LICENSE_FILE }}
       gams_license: ${{ secrets.GAMS_LICENSE_FILE }}

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: [ self-hosted, docker ]
     steps:
     - name: Run Benchmark
-      uses: maxemiliang/shot-benchmarker@v1.4
+      uses: maxemiliang/shot-benchmarker@v1.5
       with:
         benchmark_folder: "MINLP-convex-small"
         benchmark_type: "nl"

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -42,6 +42,11 @@ jobs:
     with:
       benchmark_folder: "MINLP-convex-small"
       benchmark_type: "nl"
+      enable_gurobi: true
+      enable_gams: true
+    secrets:
+      gurobi_license: ${{ secrets.GUROBI_LICENSE_FILE }}
+      gams_license: ${{ secrets.GAMS_LICENSE_FILE }}
 
   # Publish the test results as an output
   publish-test:

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -34,24 +34,8 @@ jobs:
       gurobi_license: ${{ secrets.GUROBI_LICENSE_FILE }}
       gams_license: ${{ secrets.GAMS_LICENSE_FILE }}
 
-  # Finally, we run some simple benchmarks
-  benchmark:
-    name: Benchmark
-    needs: [ build-test, build-proprietary ]
-    uses: ./.github/workflows/benchmarker.yml
-    with:
-      benchmark_folder: "MINLP-convex-small"
-      benchmark_type: "nl"
-      enable_gurobi: false
-      enable_gams: false
-      shot_artifact: shot-binary-${{ github.sha }}
-    secrets:
-      gurobi_license: ${{ secrets.GUROBI_LICENSE_FILE }}
-      gams_license: ${{ secrets.GAMS_LICENSE_FILE }}
-      OS_USERNAME: ${{ secrets.OS_USERNAME }}
-      OS_PASSWORD: ${{ secrets.OS_PASSWORD }}
 
-   # Publish the test results as an output
+  # Publish the test results as an output
   publish-test:
     name: Publish test results
     needs: [ build-test, build-proprietary, benchmark ]

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -8,14 +8,14 @@ concurrency: push-build
 
 jobs:
   # First, we build and test using the default build options and only open source external libraries
-#  build-test:
-#    name: Build & Test
-#    uses: ./.github/workflows/build-workflow.yml
-#    with:
-#      job_count: 4
-#      build_type: Release
-#      retention: 30
-#      upload_artifacts: true
+  build-test:
+    name: Build & Test
+    uses: ./.github/workflows/build-workflow.yml
+    with:
+      job_count: 4
+      build_type: Release
+      retention: 30
+      upload_artifacts: true
 
   # Then, we build and test using all licenses included proprietary ones
 #  build-proprietary:
@@ -37,14 +37,14 @@ jobs:
   # Finally, we run some simple benchmarks
   benchmark:
     name: Benchmark
-#    needs: [ build-test ]
+    needs: [ build-test ]
     uses: ./.github/workflows/benchmarker.yml
     with:
       benchmark_folder: "MINLP-convex-small"
       benchmark_type: "nl"
       enable_gurobi: false
       enable_gams: false
-      shot_artifact: shot-binary-b22eca247cc8986be66df8f7e5a9cbe6e55a1f70
+      shot_artifact: shot-binary-${{ github.sha }}
     secrets:
       gurobi_license: ${{ secrets.GUROBI_LICENSE_FILE }}
       gams_license: ${{ secrets.GAMS_LICENSE_FILE }}

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -8,14 +8,14 @@ concurrency: push-build
 
 jobs:
   # First, we build and test using the default build options and only open source external libraries
-  build-test:
-    name: Build & Test
-    uses: ./.github/workflows/build-workflow.yml
-    with:
-      job_count: 4
-      build_type: Release
-      retention: 30
-      upload_artifacts: true
+#  build-test:
+#    name: Build & Test
+#    uses: ./.github/workflows/build-workflow.yml
+#    with:
+#      job_count: 4
+#      build_type: Release
+#      retention: 30
+#      upload_artifacts: true
 
   # Then, we build and test using all licenses included proprietary ones
 #  build-proprietary:
@@ -37,7 +37,7 @@ jobs:
   # Finally, we run some simple benchmarks
   benchmark:
     name: Benchmark
-    needs: [ build-test ]
+#    needs: [ build-test ]
     uses: ./.github/workflows/benchmarker.yml
     with:
       benchmark_folder: "MINLP-convex-small"
@@ -45,20 +45,20 @@ jobs:
       shot_executable: ${{ github.workspace }}/build/SHOT
 
   # Publish the test results as an output
-  publish-test:
-    name: Publish test results
-    needs: [ build-test ]
-    runs-on: [ self-hosted, docker ]
-    steps:
-      - uses: actions/download-artifact@v3
-        name: Download artifacts
-        with:
-          path: artifacts
-
-      - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
-        if: always()
-        with:
-          files: |
-            artifacts/test-*/*.xml
+#  publish-test:
+#    name: Publish test results
+#    needs: [ build-test ]
+#    runs-on: [ self-hosted, docker ]
+#    steps:
+#      - uses: actions/download-artifact@v3
+#        name: Download artifacts
+#        with:
+#          path: artifacts
+#
+#      - name: Publish Test Results
+#        uses: EnricoMi/publish-unit-test-result-action@v2
+#        if: always()
+#        with:
+#          files: |
+#            artifacts/test-*/*.xml
 

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -18,21 +18,21 @@ jobs:
       upload_artifacts: true
 
 #  # Then, we build and test using all licenses included proprietary ones
-#  build-proprietary:
-#    name: Build & Test (Proprietary licenses)
-#    needs: [ build-test ]
-#    uses: ./.github/workflows/build-workflow.yml
-#    with:
-#      job_count: 4
-#      build_type: Release
-#      retention: 30
-#      upload_artifacts: false
-#      enable_gurobi: true
-#      enable_gams: true
-#      artifact_suffix: '-proprietary'
-#    secrets:
-#      gurobi_license: ${{ secrets.GUROBI_LICENSE_FILE }}
-#      gams_license: ${{ secrets.GAMS_LICENSE_FILE }}
+  build-proprietary:
+    name: Build & Test (Proprietary licenses)
+    needs: [ build-test ]
+    uses: ./.github/workflows/build-workflow.yml
+    with:
+      job_count: 4
+      build_type: Release
+      retention: 30
+      upload_artifacts: false
+      enable_gurobi: true
+      enable_gams: true
+      artifact_suffix: '-proprietary'
+    secrets:
+      gurobi_license: ${{ secrets.GUROBI_LICENSE_FILE }}
+      gams_license: ${{ secrets.GAMS_LICENSE_FILE }}
 
   # Finally, we run some simple benchmarks
   benchmark:

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -48,7 +48,7 @@ jobs:
     needs: [ build-test, build-proprietary ]
     runs-on: [ self-hosted, docker ]
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         name: Download artifacts
         with:
           path: artifacts

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -42,7 +42,6 @@ jobs:
     with:
       benchmark_folder: "MINLP-convex-small"
       benchmark_type: "nl"
-      shot_executable: ${{ github.workspace }}/build/SHOT
 
   # Publish the test results as an output
 #  publish-test:

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -105,8 +105,6 @@ jobs:
       - name: Cleanup workspace
         run: |
           sudo rm -rf ./* || true
-        rm -rf ./* || true
-      3
           sudo rm -rf ./.??* || true
 
       - uses: actions/checkout@v3

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -300,11 +300,11 @@ jobs:
         if: ${{ inputs.upload_artifacts }}
         shell: bash
         run: |
-          echo "test=test-logs-${{ env.VERSION }}" >> $GITHUB_OUTPUT
-          echo "options=shot-optsfile-${{ env.VERSION }}" >> $GITHUB_OUTPUT
-          echo "binary=shot-binary-${{ env.VERSION }}" >> $GITHUB_OUTPUT
-          echo "package=shot-package-${{ env.VERSION }}" >> $GITHUB_OUTPUT
-          echo "library=shot-libraries-${{ env.VERSION }}" >> $GITHUB_OUTPUT
+          echo "test=test-logs-${{ env.VERSION }}${{ env.ARTIFACT_SUFFIX }}" >> $GITHUB_OUTPUT
+          echo "options=shot-optsfile-${{ env.VERSION }}${{ env.ARTIFACT_SUFFIX }}" >> $GITHUB_OUTPUT
+          echo "binary=shot-binary-${{ env.VERSION }}${{ env.ARTIFACT_SUFFIX }}" >> $GITHUB_OUTPUT
+          echo "package=shot-package-${{ env.VERSION }}${{ env.ARTIFACT_SUFFIX }}" >> $GITHUB_OUTPUT
+          echo "library=shot-libraries-${{ env.VERSION }}${{ env.ARTIFACT_SUFFIX }}" >> $GITHUB_OUTPUT
 
       - name: Output test artifacts
         if: ${{ inputs.upload_artifacts }} != true && steps.output-artifacts.outcome != 'success'

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -178,7 +178,7 @@ jobs:
           version_without_dot=$(echo $version | tr -d .) 
           echo "GUROBI_SHORT_VERSION=$major_minor" >> $GITHUB_ENV
           echo "GUROBI_VERSION_WITHOUT_DOT=$version_without_dot" >> $GITHUB_ENV
-          echo "GRB_INSTALL_PATH=${{ github.workspace }}/ThirdParty/gurobi$version_without_dot" >> $GITHUB_ENV
+          echo "GRB_INSTALL_PATH=${{ github.workspace }}/ThirdParty/gurobi${version_without_dot}" >> $GITHUB_ENV
 
       # Then we download and install Gurobi
       - name: Download Gurobi
@@ -208,8 +208,8 @@ jobs:
           version=${{ env.GAMS_VERSION }}
           major_minor=$(echo $version | awk -F '.' '{print $1 "." $2}')
           echo "GAMS_SHORT_VERSION=$major_minor" >> $GITHUB_ENV
-          echo "GAMS_INSTALL_PATH=${{ github.workspace }}/ThirdParty/gams$major_minor_linux_x64_64_sfx" >> $GITHUB_ENV
-          echo "GAMS_LICENSE_FILE=${{ github.workspace }}/ThirdParty/gams$major_minor_linux_x64_64_sfx/gamslice.txt" >> $GITHUB_ENV
+          echo "GAMS_INSTALL_PATH=${{ github.workspace }}/ThirdParty/gams${major_minor}_linux_x64_64_sfx" >> $GITHUB_ENV
+          echo "GAMS_LICENSE_FILE=${{ github.workspace }}/ThirdParty/gams${major_minor}_linux_x64_64_sfx/gamslice.txt" >> $GITHUB_ENV
 
       # Next, we set up GAMS
       # Download GAMS

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -215,19 +215,20 @@ jobs:
         run: echo "GAMS_OPTIONS=-DHAS_GAMS=on" >> $GITHUB_ENV
 
       - name: Configure CMake
-        # Use a bash shell so we can use the same syntax for environment variable
+        # Uses bash shell, so we can use the same syntax for environment variable
         # access regardless of the host operating system
         shell: bash
         working-directory: ${{github.workspace}}/build
-        # Note the current convention is to use the -S and -B options here to specify source
-        # and build directories, but this is only available with CMake 3.13 and higher.
-        # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DHAS_CBC=on -DCBC_DIR=${{github.workspace}}/ThirdParty/Cbc -DHAS_IPOPT=ON -DIPOPT_DIR=${{github.workspace}}/ThirdParty/Ipopt -DGAMS_DIR=$GAMS_INSTALL_PATH -DGUROBI_DIR=$GRB_INSTALL_PATH -DCOMPILE_TESTS=on -DSPDLOG_STATIC=on $GAMS_OPTIONS $GUROBI_OPTIONS -DHAS_CPLEX=off
+        # Here we configure the build, we set the build type,
+        # enable the tests and set the path to the external libraries.
+        run: cmake -S $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DHAS_CBC=on -DCBC_DIR=${{github.workspace}}/ThirdParty/Cbc -DHAS_IPOPT=ON -DIPOPT_DIR=${{github.workspace}}/ThirdParty/Ipopt -DGAMS_DIR=$GAMS_INSTALL_PATH -DGUROBI_DIR=$GRB_INSTALL_PATH -DCOMPILE_TESTS=on -DSPDLOG_STATIC=on $GAMS_OPTIONS $GUROBI_OPTIONS -DHAS_CPLEX=off
 
       - name: Build
         working-directory: ${{github.workspace}}/build
         shell: bash
-        # Execute the build.  You can specify a specific target with "--target <NAME>"
+        # We build the job, $BUILD_TYPE can be Release, Debug, RelWithDebInfo.
+        # $JOB_COUNT is the amount of jobs to use when building the program and dependencies,
+        # this can be set as an input.
         run: cmake --build . --config $BUILD_TYPE -j $JOB_COUNT
 
       - name: Generate Optionsfile
@@ -239,15 +240,11 @@ jobs:
         id: test
         working-directory: ${{github.workspace}}/build
         shell: bash
-        # Execute tests defined by the CMake configuration.
-        # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
         run: ctest -C $BUILD_TYPE --output-on-failure --output-junit test-output/ctest-junit-output.xml --output-log test-output/ctest-test.log
 
       - name: Construct package
         working-directory: ${{github.workspace}}/build
         shell: bash
-        # Execute tests defined by the CMake configuration.
-        # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
         run: make package
 
         # This will always run as we always want the test output, however if the files are not found, we just warn the user.

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -56,7 +56,7 @@ on:
         type: string
       gams_version:
         description: 'The version of GAMS to use'
-        default: '46.4.0'
+        default: '42.3.0'
         required: false
         type: string
     secrets:

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -174,7 +174,7 @@ jobs:
         id: get_version
         run: |
           version=${{ env.GUROBI_VERSION }}
-          major_minor=$(echo version | awk -F '.' '{print $1 "." $2}')
+          major_minor=$(echo $version | awk -F '.' '{print $1 "." $2}')
           version_without_dot=$(echo $version | tr -d .) 
           echo "GUROBI_SHORT_VERSION=$major_minor" >> $GITHUB_ENV
           echo "GUROBI_VERSION_WITHOUT_DOT=$version_without_dot" >> $GITHUB_ENV
@@ -206,7 +206,7 @@ jobs:
         id: get_gams_short_version
         run: |
           version=${{ env.GAMS_VERSION }}
-          major_minor=$(echo version | awk -F '.' '{print $1 "." $2}')
+          major_minor=$(echo $version | awk -F '.' '{print $1 "." $2}')
           echo "GAMS_SHORT_VERSION=$major_minor" >> $GITHUB_ENV
           echo "GAMS_INSTALL_PATH=${{ github.workspace }}/ThirdParty/gams${{ env.GAMS_SHORT_VERSION }}_linux_x64_64_sfx" >> $GITHUB_ENV
           echo "GAMS_LICENSE_FILE=${{ github.workspace }}/ThirdParty/gams${{ env.GAMS_SHORT_VERSION }}_linux_x64_64_sfx/gamslice.txt" >> $GITHUB_ENV

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -382,6 +382,7 @@ jobs:
       enable_gams: ${{ inputs.enable_gams }}
       gurobi_license_file: ${{ needs.build.outputs.gurobi_license_file }}
       gams_license_file: ${{ needs.build.outputs.gams_license_file }}
+      artifact_suffix: ${{ inputs.artifact_suffix }}
     secrets:
       gurobi_license: ${{ secrets.gurobi_license }}
       gams_license: ${{ secrets.gams_license }}

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -366,7 +366,7 @@ jobs:
     uses: ./.github/workflows/benchmarker.yml
     needs: [ build ]
     with:
-      shot_executable_path: ${{ github.workspace }}/build
+      shot_executable_path: build
       benchmark_folder: "MINLP-convex-small"
       benchmark_type: "nl"
       enable_gurobi: ${{ inputs.enable_gurobi }}

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -49,6 +49,16 @@ on:
         default: ''
         required: false
         type: string
+      gurobi_version:
+        description: 'The version of Gurobi to use'
+        default: '11.0.1'
+        required: false
+        type: string
+      gams_version:
+        description: 'The version of GAMS to use'
+        default: '46.4.0'
+        required: false
+        type: string
     secrets:
       gurobi_license:
         description: 'Gurobi license file secret'
@@ -82,9 +92,8 @@ env:
   ARTIFACT_SUFFIX: ${{ inputs.artifact_suffix }}
   EXTRA_BUILD_ARGS: ${{ inputs.build_args }}
   GRB_LICENSE_FILE: ${{ github.workspace }}/gurobi.lic
-  GRB_INSTALL_PATH: ${{ github.workspace }}/ThirdParty/gurobi1001
-  GAMS_LICENSE_FILE: ${{ github.workspace }}/ThirdParty/gams42.3_linux_x64_64_sfx/gamslice.txt
-  GAMS_INSTALL_PATH: ${{ github.workspace }}/ThirdParty/gams42.3_linux_x64_64_sfx
+  GUROBI_VERSION: ${{ inputs.gurobi_version }}
+  GAMS_VERSION: ${{ inputs.gams_version }}
 
 jobs:
   build:
@@ -161,12 +170,22 @@ jobs:
         working-directory: ${{github.workspace}}
         run: echo ${{ secrets.gurobi_license }} | base64 -d > $GRB_LICENSE_FILE
 
+      - name: Extract Version
+        id: get_version
+        run: |
+          version=${{ env.GUROBI_VERSION }}
+          major_minor=$(echo ${version%%.*})
+          version_without_dot=$(echo $version | tr -d .) 
+          echo "GUROBI_SHORT_VERSION=$major_minor" >> $GITHUB_ENV
+          echo "GUROBI_VERSION_WITHOUT_DOT=$version_without_dot" >> $GITHUB_ENV
+          echo "GRB_INSTALL_PATH=${{ github.workspace }}/ThirdParty/gurobi${{ env.GUROBI_VERSION_WITHOUT_DOT }}" >> $GITHUB_ENV
+
       # Then we download and install Gurobi
       - name: Download Gurobi
         if: ${{ inputs.enable_gurobi }}
         shell: bash
         working-directory: ${{github.workspace}}/ThirdParty
-        run: wget -q https://packages.gurobi.com/10.0/gurobi10.0.1_linux64.tar.gz ; tar -xvf gurobi10.0.1_linux64.tar.gz ; rm gurobi10.0.1_linux64.tar.gz
+        run: wget -q https://packages.gurobi.com/${{ env.GUROBI_SHORT_VERSION }}/gurobi${{ env.GUROBI_VERSION }}_linux64.tar.gz ; tar -xvf gurobi${{ env.GUROBI_VERSION }}_linux64.tar.gz ; rm gurobi${{ env.GUROBI_VERSION }}_linux64.tar.gz
 
       # Finally, we set the environment variables needed for Gurobi to work.
       - name: Setup Gurobi environment variables
@@ -174,14 +193,23 @@ jobs:
         shell: bash
         working-directory: ${{github.workspace}}/ThirdParty
         run: |
-          echo "${{ github.workspace }}/ThirdParty/gurobi1001/linux64/bin" >> $GITHUB_PATH
-          echo "GUROBI_HOME=${{ github.workspace }}/ThirdParty/gurobi1001/linux64" >> $GITHUB_ENV
-          echo "LD_LIBRARY_PATH=${{ github.workspace }}/ThirdParty/gurobi1001/linux64/lib" >> $GITHUB_ENV
+          echo "${{ github.workspace }}/ThirdParty/gurobi${{ env.GUROBI_VERSION_WITHOUT_DOT }}/linux64/bin" >> $GITHUB_PATH
+          echo "GUROBI_HOME=${{ github.workspace }}/ThirdParty/gurobi${{ env.GUROBI_VERSION_WITHOUT_DOT }}/linux64" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=${{ github.workspace }}/ThirdParty/gurobi${{ env.GUROBI_VERSION_WITHOUT_DOT }}/linux64/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
 
       - name: Set Gurobi options
         if: ${{ inputs.enable_gurobi }}
         shell: bash
         run: echo "GUROBI_OPTIONS=-DHAS_GUROBI=on" >> $GITHUB_ENV
+
+      - name: Get GAMS short version
+        id: get_gams_short_version
+        run: |
+          version=${{ env.GAMS_VERSION }}
+          major_minor=$(echo ${version%%.*})
+          echo "GAMS_SHORT_VERSION=$major_minor" >> $GITHUB_ENV
+          echo "GAMS_INSTALL_PATH=${{ github.workspace }}/ThirdParty/gams${{ env.GAMS_SHORT_VERSION }}_linux_x64_64_sfx" >> $GITHUB_ENV
+          echo "GAMS_LICENSE_FILE=${{ github.workspace }}/ThirdParty/gams${{ env.GAMS_SHORT_VERSION }}_linux_x64_64_sfx/gamslice.txt" >> $GITHUB_ENV
 
       # Next, we set up GAMS
       # Download GAMS
@@ -189,7 +217,7 @@ jobs:
         if: ${{ inputs.enable_gams }}
         shell: bash
         working-directory: ${{github.workspace}}/ThirdParty
-        run: wget -q https://d37drm4t2jghv5.cloudfront.net/distributions/42.3.0/linux/linux_x64_64_sfx.exe ; chmod +x linux_x64_64_sfx.exe ; ./linux_x64_64_sfx.exe ; rm linux_x64_64_sfx.exe
+        run: wget -q https://d37drm4t2jghv5.cloudfront.net/distributions/${{ env.GAMS_VERSION }}/linux/linux_x64_64_sfx.exe ; chmod +x linux_x64_64_sfx.exe ; ./linux_x64_64_sfx.exe ; rm linux_x64_64_sfx.exe
 
       # Add the license file to the GAMS installation directory
       - name: Setup GAMS License file
@@ -201,7 +229,7 @@ jobs:
       - name: Install GAMS
         if: ${{ inputs.enable_gams }}
         shell: bash
-        working-directory: ${{ github.workspace }}/ThirdParty/gams42.3_linux_x64_64_sfx/
+        working-directory: ${{ github.workspace }}/ThirdParty/gams${{ env.GAMS_SHORT_VERSION }}_linux_x64_64_sfx/
         run: ./gamsinst -a
 
       - name: Add GAMS to the path

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -104,8 +104,10 @@ jobs:
     steps:
       - name: Cleanup workspace
         run: |
-          rm -rf ./* || true
-          rm -rf ./.??* || true
+          sudo rm -rf ./* || true
+        rm -rf ./* || true
+      3
+          sudo rm -rf ./.??* || true
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -275,6 +275,11 @@ jobs:
         shell: bash
         run: make package
 
+      - name: Show linked libraries
+        working-directory: ${{github.workspace}}/build
+        shell: bash
+        run: ldd SHOT
+
         # This will always run as we always want the test output, however if the files are not found, we just warn the user.
       - uses: actions/upload-artifact@v3
         if: ${{ always() }}

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -114,6 +114,8 @@ jobs:
       binary-artifact: ${{ steps.output-artifacts.binary }}
       package-artifact: ${{ steps.output-artifacts.package }}
       library-artifact: ${{ steps.output-artifacts.library }}
+      gurobi_license_file: ${{ steps.licensefiles.outputs.gurobi}}
+      gams_license_file: ${{ steps.licensefiles.outputs.gams }}
     name: Build SHOT
     runs-on: [ self-hosted, linux, cmake ]
 
@@ -253,6 +255,13 @@ jobs:
         shell: bash
         run: echo "GAMS_OPTIONS=-DHAS_GAMS=on" >> $GITHUB_ENV
 
+      - name: Output License files
+        id: licensefiles
+        shell: bash
+        run: |
+          echo "gurobi=${{ github.workspace }}/ThirdParty/gurobi${{ env.GUROBI_VERSION_WITHOUT_DOT }}/linux64/bin/gurobi.lic" >> $GITHUB_OUTPUT
+          echo "gams=${{ github.workspace }}/ThirdParty/gams${{ env.GAMS_SHORT_VERSION }}_linux_x64_64_sfx/gamslice.txt" >> $GITHUB_OUTPUT
+
       - name: Configure CMake
         # Uses bash shell, so we can use the same syntax for environment variable
         # access regardless of the host operating system
@@ -371,8 +380,8 @@ jobs:
       benchmark_type: "nl"
       enable_gurobi: ${{ inputs.enable_gurobi }}
       enable_gams: ${{ inputs.enable_gams }}
-      gurobi_license_file: ${{ env.GUROBI_LICENSE_FILE }}
-      gams_license_file: ${{ env.GAMS_LICENSE_FILE }}
+      gurobi_license_file: ${{ needs.build.outputs.gurobi_license_file }}
+      gams_license_file: ${{ needs.build.outputs.gams_license_file }}
     secrets:
       gurobi_license: ${{ secrets.gurobi_license }}
       gams_license: ${{ secrets.gams_license }}

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -59,12 +59,23 @@ on:
         default: '42.3.0'
         required: false
         type: string
+      run_benchmarks:
+        description: 'Should the benchmarks be run'
+        default: false
+        required: false
+        type: boolean
     secrets:
       gurobi_license:
         description: 'Gurobi license file secret'
         required: false
       gams_license:
         description: 'GAMS license file secret'
+        required: false
+      OS_USERNAME:
+        description: 'OpenStack username'
+        required: false
+      OS_PASSWORD:
+        description: 'OpenStack password'
         required: false
 
     outputs:
@@ -350,8 +361,10 @@ jobs:
 
   # Finally, we run some simple benchmarks
   benchmark:
+    if: ${{ inputs.run_benchmarks }}
     name: Benchmark
     uses: ./.github/workflows/benchmarker.yml
+    needs: [ build ]
     with:
       shot_executable_path: "${{ github.workspace }}/build"
       benchmark_folder: "MINLP-convex-small"

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -347,3 +347,19 @@ jobs:
         run: |
           rm -f $GRB_LICENSE_FILE
           rm -f $GAMS_LICENSE_FILE
+
+  # Finally, we run some simple benchmarks
+  benchmark:
+    name: Benchmark
+    uses: ./.github/workflows/benchmarker.yml
+    with:
+      shot_executable_path: "${{ github.workspace }}/build"
+      benchmark_folder: "MINLP-convex-small"
+      benchmark_type: "nl"
+      enable_gurobi: ${{ inputs.enable_gurobi }}
+      enable_gams: ${{ inputs.enable_gams }}
+    secrets:
+      gurobi_license: ${{ secrets.GUROBI_LICENSE_FILE }}
+      gams_license: ${{ secrets.GAMS_LICENSE_FILE }}
+      OS_USERNAME: ${{ secrets.OS_USERNAME }}
+      OS_PASSWORD: ${{ secrets.OS_PASSWORD }}

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -89,11 +89,11 @@ env:
 jobs:
   build:
     outputs:
-      test-artifact: ${{ steps.artifact_outputs.test }}
-      options-artifact: ${{ steps.artifact_outputs.options }}
-      binary-artifact: ${{ steps.artifact_outputs.binary }}
-      package-artifact: ${{ steps.artifact_outputs.package }}
-      library-artifact: ${{ steps.artifact_outputs.library }}
+      test-artifact: ${{ steps.output-artifacts.test }}
+      options-artifact: ${{ steps.output-artifacts.options }}
+      binary-artifact: ${{ steps.output-artifacts.binary }}
+      package-artifact: ${{ steps.output-artifacts.package }}
+      library-artifact: ${{ steps.output-artifacts.library }}
     name: Build SHOT
     runs-on: [ self-hosted, linux, cmake ]
 

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -366,7 +366,7 @@ jobs:
     uses: ./.github/workflows/benchmarker.yml
     needs: [ build ]
     with:
-      shot_executable_path: "${{ github.workspace }}/build"
+      shot_executable_path: ${{ github.workspace }}/build
       benchmark_folder: "MINLP-convex-small"
       benchmark_type: "nl"
       enable_gurobi: ${{ inputs.enable_gurobi }}

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -371,8 +371,10 @@ jobs:
       benchmark_type: "nl"
       enable_gurobi: ${{ inputs.enable_gurobi }}
       enable_gams: ${{ inputs.enable_gams }}
+      gurobi_license_file: ${{ env.GUROBI_LICENSE_FILE }}
+      gams_license_file: ${{ env.GAMS_LICENSE_FILE }}
     secrets:
-      gurobi_license: ${{ secrets.GUROBI_LICENSE_FILE }}
-      gams_license: ${{ secrets.GAMS_LICENSE_FILE }}
+      gurobi_license: ${{ secrets.gurobi_license }}
+      gams_license: ${{ secrets.gams_license }}
       OS_USERNAME: ${{ secrets.OS_USERNAME }}
       OS_PASSWORD: ${{ secrets.OS_PASSWORD }}

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -292,7 +292,7 @@ jobs:
         run: ldd SHOT
 
         # This will always run as we always want the test output, however if the files are not found, we just warn the user.
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ always() }}
         name: Upload test results
         with:
@@ -302,7 +302,7 @@ jobs:
             ${{github.workspace}}/build/test-output/*.xml
           retention-days: ${{ inputs.retention }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ inputs.upload_artifacts }}
         name: Upload SHOT Optionsfile
         with:
@@ -310,7 +310,7 @@ jobs:
           path: ${{github.workspace}}/build/SHOT.opt
           retention-days: ${{ inputs.retention }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ inputs.upload_artifacts }}
         name: Upload SHOT File
         with:
@@ -318,7 +318,7 @@ jobs:
           path: ${{github.workspace}}/build/SHOT
           retention-days: ${{ inputs.retention }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ inputs.upload_artifacts }}
         name: Upload SHOT Package file
         with:
@@ -326,7 +326,7 @@ jobs:
           path: ${{github.workspace}}/build/SHOT-*-Linux.zip
           retention-days: ${{ inputs.retention }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ inputs.upload_artifacts }}
         name: Upload SHOT Libraries
         with:

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -174,7 +174,7 @@ jobs:
         id: get_version
         run: |
           version=${{ env.GUROBI_VERSION }}
-          major_minor=$(echo ${version%%.*})
+          major_minor=$(echo version | awk -F '.' '{print $1 "." $2}')
           version_without_dot=$(echo $version | tr -d .) 
           echo "GUROBI_SHORT_VERSION=$major_minor" >> $GITHUB_ENV
           echo "GUROBI_VERSION_WITHOUT_DOT=$version_without_dot" >> $GITHUB_ENV
@@ -206,7 +206,7 @@ jobs:
         id: get_gams_short_version
         run: |
           version=${{ env.GAMS_VERSION }}
-          major_minor=$(echo ${version%%.*})
+          major_minor=$(echo version | awk -F '.' '{print $1 "." $2}')
           echo "GAMS_SHORT_VERSION=$major_minor" >> $GITHUB_ENV
           echo "GAMS_INSTALL_PATH=${{ github.workspace }}/ThirdParty/gams${{ env.GAMS_SHORT_VERSION }}_linux_x64_64_sfx" >> $GITHUB_ENV
           echo "GAMS_LICENSE_FILE=${{ github.workspace }}/ThirdParty/gams${{ env.GAMS_SHORT_VERSION }}_linux_x64_64_sfx/gamslice.txt" >> $GITHUB_ENV

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -178,7 +178,7 @@ jobs:
           version_without_dot=$(echo $version | tr -d .) 
           echo "GUROBI_SHORT_VERSION=$major_minor" >> $GITHUB_ENV
           echo "GUROBI_VERSION_WITHOUT_DOT=$version_without_dot" >> $GITHUB_ENV
-          echo "GRB_INSTALL_PATH=${{ github.workspace }}/ThirdParty/gurobi${{ env.GUROBI_VERSION_WITHOUT_DOT }}" >> $GITHUB_ENV
+          echo "GRB_INSTALL_PATH=${{ github.workspace }}/ThirdParty/gurobi$version_without_dot" >> $GITHUB_ENV
 
       # Then we download and install Gurobi
       - name: Download Gurobi
@@ -208,8 +208,8 @@ jobs:
           version=${{ env.GAMS_VERSION }}
           major_minor=$(echo $version | awk -F '.' '{print $1 "." $2}')
           echo "GAMS_SHORT_VERSION=$major_minor" >> $GITHUB_ENV
-          echo "GAMS_INSTALL_PATH=${{ github.workspace }}/ThirdParty/gams${{ env.GAMS_SHORT_VERSION }}_linux_x64_64_sfx" >> $GITHUB_ENV
-          echo "GAMS_LICENSE_FILE=${{ github.workspace }}/ThirdParty/gams${{ env.GAMS_SHORT_VERSION }}_linux_x64_64_sfx/gamslice.txt" >> $GITHUB_ENV
+          echo "GAMS_INSTALL_PATH=${{ github.workspace }}/ThirdParty/gams$major_minor_linux_x64_64_sfx" >> $GITHUB_ENV
+          echo "GAMS_LICENSE_FILE=${{ github.workspace }}/ThirdParty/gams$major_minor_linux_x64_64_sfx/gamslice.txt" >> $GITHUB_ENV
 
       # Next, we set up GAMS
       # Download GAMS

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@
 build/*
 /.vs
 /out/build
+/.cache/

--- a/misc/runner-init.yml
+++ b/misc/runner-init.yml
@@ -18,6 +18,7 @@ packages:
   - curl
   - gnupg
   - lsb-release
+  - ccache
 
 users:
   - default


### PR DESCRIPTION
This PR updates the GHA workflow in a number of ways.
1. Workflows are now run on CSC hosted runners, to allow for consistent performance.
2. It builds & tests SHOT with both Ipopt/Cbc and proprietary solvers (currently GAMS and Gurobi).
3. It uploads many of the build/test/configuration files as artifacts to allow for comparison between versions and for local inspection
4. It runs benchmarks and compares the results to previous commits in the same branch (and same solvers).
5. Benchmark results are output in a Markdown summary.
6. It outputs the tests results in a Markdown summary.
It also adds a way to manually dispatch the different workflows.

It also adds a cloud-init script to allow for smooth setup of the self-hosted runner, documentation for this will follow.

The benchmarker code can be found in this [Repo](https://github.com/maxemiliang/shot-benchmarker)
