### PR TITLE
switch from NullNlHandler to NlHandler to get exceptions on unsupported

### DIFF
--- a/src/ModelingSystem/ModelingSystemAMPL.cpp
+++ b/src/ModelingSystem/ModelingSystemAMPL.cpp
@@ -418,6 +418,18 @@ public:
         destination->numericConstraints[index]->valueRHS = ub;
     }
 
+    /** initial values are ignored for now */
+    void OnInitialValue(int var_index, double value) { }
+
+    /** initial dual values are ignored */
+    void OnInitialDualValue(int con_index, double value) { }
+
+    /** Jacobian column sizes are ignored */
+    ColumnSizeHandler OnColumnSizes() {
+        // return NLHandler's handler that does nothing
+        return ColumnSizeHandler();
+    }
+
     /// handling of suffices for variable and constraint flags and SOS constraints
     ///
     /// regarding SOS in AMPL, see https://ampl.com/faqs/how-can-i-use-the-solvers-special-ordered-sets-feature/

--- a/src/ModelingSystem/ModelingSystemAMPL.cpp
+++ b/src/ModelingSystem/ModelingSystemAMPL.cpp
@@ -48,7 +48,7 @@ namespace SHOT
 using MPProblem = mp::Problem;
 using MPProblemPtr = std::shared_ptr<MPProblem>;
 
-class AMPLProblemHandler : public mp::NullNLHandler<NonlinearExpressionPtr>
+class AMPLProblemHandler : public mp::NLHandler<AMPLProblemHandler, NonlinearExpressionPtr>
 {
 private:
     EnvironmentPtr env;


### PR DESCRIPTION
On instances that SHOT cannot handle, e.g., https://www.minlplib.org/nl/fuzzy.nl, one gets a segmentation fault, because exceptions for unsupported constructs are suppressed and then SHOT tries to work with expression that are only partially constructed (a negate with NULL child for `fuzzy.nl`).

With this PR, an `mp::UnsupportedError` exception are thrown again, so that SHOT stops nicely with
```
Error when reading AMPL model from "fuzzy.nl": unsupported: vararg expression
```

The reason to derive from `mp::NullNLHandler` was probably to ignore some optional data from the nl file, like the initial point. So this adds explicit empty handling of these.