### PR TITLE
support for new gams option and attribute

### DIFF
--- a/src/ModelingSystem/ModelingSystemGAMS.cpp
+++ b/src/ModelingSystem/ModelingSystemGAMS.cpp
@@ -324,6 +324,15 @@ E_ProblemCreationStatus ModelingSystemGAMS::createProblem(ProblemPtr& problem)
         return (E_ProblemCreationStatus::CapabilityProblem);
     }
 #endif
+
+#if GEVAPIVERSION >= 10
+   if( gevGetIntOpt(modelingEnvironment, gevRequestMarginals) == 2 )
+   {
+      gevLogStat(modelingEnvironment, "Capability error: SHOT does not provide dual solutions, but requestMarginals has been set to 2.");
+      return (E_ProblemCreationStatus::CapabilityProblem);
+   }
+#endif
+
     try
     {
         gmoNameInput(modelingObject, buffer);

--- a/src/ModelingSystem/ModelingSystemGAMS.cpp
+++ b/src/ModelingSystem/ModelingSystemGAMS.cpp
@@ -718,6 +718,9 @@ void ModelingSystemGAMS::finalizeSolution()
 
     // set some more statistics, etc
     gmoSetHeadnTail(modelingObject, gmoTmipbest, r->getGlobalDualBound());
+#if GMOAPIVERSION >= 30
+    gmoSetHeadnTail(modelingObject, gmoTrelgap, r->getRelativeGlobalObjectiveGap());
+#endif
     gmoSetHeadnTail(modelingObject, gmoHiterused, r->getCurrentIteration()->iterationNumber);
     // TODO this seems to be 0: gmoSetHeadnTail(modelingObject, gmoHiterused,
     // env->solutionStatistics.numberOfIterations);


### PR DESCRIPTION
- if new gams options `requestmarginals` is set to 2, then the link should return a capability error
- set upcoming attribute for relative gap to the relative gap as computed by shot