### PR TITLE
Add Uno as NLP solver in SHOT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,9 @@ set(CBC_DIR "/opt/cbc" CACHE STRING "The base directory where Cbc is located (if
 option(HAS_IPOPT "Is Ipopt available" ON)
 set(IPOPT_DIR "/opt/ipopt" CACHE STRING "The base directory where Ipopt is located (if available).")
 
+option(HAS_UNO "Is Uno available" OFF)
+set(UNO_DIR "/opt/uno" CACHE STRING "The base directory where Uno is located (if available).")
+
 # Python
 option(HAS_PYTHON "Is Python available" OFF)
 
@@ -371,6 +374,24 @@ if(HAS_IPOPT)
     set(PRIMAL_HEADERS "${PROJECT_SOURCE_DIR}/src/NLPSolver/NLPSolverIpoptBase.h")
     set(PRIMAL_HEADERS ${PRIMAL_HEADERS} "${PROJECT_SOURCE_DIR}/src/NLPSolver/NLPSolverIpoptRelaxed.h")
 endif(HAS_IPOPT)
+
+if(HAS_UNO)
+    find_package(Uno)
+
+    if(NOT UNO_FOUND)
+        message(WARNING "Uno not found, setting HAS_UNO to OFF")
+        set(HAS_UNO OFF)
+    endif()
+
+    if(UNO_FOUND)
+        # Defined here rather than in the linking section further down so that the definition reaches every
+        # target declared after this point, including the test executables.
+        add_definitions(-DHAS_UNO)
+
+        set(PRIMAL_SOURCES ${PRIMAL_SOURCES} "${PROJECT_SOURCE_DIR}/src/NLPSolver/NLPSolverUno.cpp")
+        set(PRIMAL_HEADERS ${PRIMAL_HEADERS} "${PROJECT_SOURCE_DIR}/src/NLPSolver/NLPSolverUno.h")
+    endif()
+endif(HAS_UNO)
 
 # AMPL interface
 
@@ -847,6 +868,16 @@ if(HAS_IPOPT)
     message("-- The following Ipopt libraries will be used from: ${IPOPT_LIBRARY_DIRS}")
     message("   ${IPOPT_LIBRARIES}")
 endif(HAS_IPOPT)
+
+# Uno linking
+if(HAS_UNO)
+    message("-- Uno include files will be used from: ${UNO_INCLUDE_DIR}")
+    target_link_libraries(SHOTPrimalStrategy ${UNO_LIBRARIES})
+    target_include_directories(SHOTPrimalStrategy SYSTEM PUBLIC "${UNO_INCLUDE_DIR}")
+
+    message("-- The following Uno libraries will be used:")
+    message("   ${UNO_LIBRARIES}")
+endif(HAS_UNO)
 
 # GAMS linking
 if(HAS_GAMS)

--- a/docs/CommandLineUsage.md
+++ b/docs/CommandLineUsage.md
@@ -50,7 +50,7 @@ pass `--AMPL` (or `-AMPL`) in addition to the problem file (only valid for
 | `--convex` | Assumes the problem is convex (sets `Model.Convexity.AssumeConvex=true`) |
 | `--debug` / `--debug=<directory>` | Enables debug-output mode; see [DebuggingSHOT.md](DebuggingSHOT.md) |
 | `--mip=<cbc\|highs\|cplex\|gurobi>` | Selects the MIP (dual) solver — only the ones the build was compiled with are available |
-| `--nlp=<ipopt\|gams\|shot>` | Selects the primal NLP solver |
+| `--nlp=<ipopt\|gams\|shot\|uno>` | Selects the primal NLP solver |
 | `--tree=<single\|multi>` | Selects single-tree (branch-and-cut) vs. multi-tree dual strategy — single-tree requires solver callback support, currently only available with CPLEX or Gurobi; Cbc and HiGHS are always forced to multi-tree |
 | `--threads=<n>` | Maximum number of threads (`Dual.MIP.NumberOfThreads`) |
 | `--absgap=<value>` | Absolute objective gap termination tolerance (`Termination.ObjectiveGap.Absolute`) |

--- a/docs/CompilationInstructions.md
+++ b/docs/CompilationInstructions.md
@@ -77,6 +77,47 @@ cd coinbrew
 then point CMake at them with `-DCBC_DIR=<SHOT>/ThirdParty/Cbc
 -DIPOPT_DIR=<SHOT>/ThirdParty/Ipopt` (see section 3).
 
+#### Uno (optional)
+
+[Uno](https://github.com/cvanaret/Uno) is an alternative NLP solver for the
+fixed-integer primal heuristic. It is off by default and has to be built from
+source; there is no distribution package.
+
+Building Uno requires a **Fortran compiler** and BLAS/LAPACK. Beyond that, Uno
+needs at least one subproblem solver to be compiled into it, or it cannot solve
+constrained NLPs at all:
+
+* an **interior-point** method (the `ipopt` preset) needs MUMPS, HSL or SPRAL
+  SSIDS — note that MUMPS has to provide `dmumps_c.h`, which the MUMPS shipped
+  inside some Ipopt distributions does not;
+* an **SQP** method (the `filtersqp` preset) needs BQPD or HiGHS.
+
+Which of these is available matters for how much of SHOT's workload Uno can
+take on: HiGHS refuses negative curvature outright, so an Uno built with only
+HiGHS solves convex fixed NLPs but fails on the nonconvex ones that SHOT
+frequently produces. BQPD, or an interior-point build with MUMPS or HSL, is the
+better fit.
+
+Uno installs neither a CMake package configuration file nor a pkg-config file,
+so SHOT locates it with `misc/FindUno.cmake` and the `UNO_DIR` cache variable.
+A shared build is easiest, since a static `libuno.a` has to be linked together
+with BLAS/LAPACK and the Fortran runtime.
+
+```bash
+git clone https://github.com/cvanaret/Uno
+cmake -S Uno -B Uno/build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON \
+    -DBUILD_STATIC_LIBS=OFF -DCMAKE_INSTALL_PREFIX=<SHOT>/ThirdParty/Uno
+cmake --build Uno/build -j && cmake --install Uno/build
+```
+
+then configure SHOT with `-DHAS_UNO=on -DUNO_DIR=<SHOT>/ThirdParty/Uno`.
+
+If Uno reports `Found HIGHS` but then fails to compile with `'Highs.h' file not
+found`, pass `-DHIGHS_INCLUDE_DIR=<path to the HiGHS headers>` as well: Uno
+locates the HiGHS library and its headers independently. On macOS, a Homebrew
+GCC also needs `-DCMAKE_SHARED_LINKER_FLAGS=-L$(brew --prefix gcc)/lib/gcc/current`
+so that the linker finds `libgfortran`.
+
 ### macOS (Homebrew)
 
 ```bash
@@ -133,6 +174,7 @@ Key options (all `option(...)` declarations live at the top of the root
 | `HAS_GUROBI` | `ON` | Gurobi MIP solver |
 | `HAS_HIGHS` | `ON` | HiGHS MIP solver — like the others, optional; turn off with `-DHAS_HIGHS=off` (see section 1 re: `USE_EXTERNAL_HIGHS`) |
 | `HAS_IPOPT` | `ON` | Ipopt NLP solver |
+| `HAS_UNO` | `OFF` | Uno NLP solver (see section 2) — off by default because building Uno needs a Fortran compiler |
 | `HAS_GAMS` | `ON` | GAMS interface (modeling system + NLP solver) |
 | `HAS_AMPL` | `ON` | AMPL/ASL `.nl` file interface |
 | `HAS_PYTHON` | `OFF` | Build the `SHOTpy` Python bindings (needs Python3 dev headers; pybind11 comes from the submodule) |

--- a/docs/DebuggingSHOT.md
+++ b/docs/DebuggingSHOT.md
@@ -342,6 +342,16 @@ in this codebase — add to this list as you find more.
   `usedsettings.opt` that the solver/setting you intended is actually the
   one in effect.
 
+- `createSetting(name, "", description)` does **not** create a string
+  setting. A string literal is a `const char*`, and converting that to
+  `bool` is a standard conversion while converting it to `std::string` is
+  a user-defined one, so overload resolution picks the `bool` overload
+  and silently creates a boolean setting. Reading it back with
+  `getSetting<std::string>` then fails with "Setting ... not found",
+  which reads like a missing `createSetting` call rather than a wrong
+  one. Write `std::string()` for an empty default, as
+  `Output.GAMS.AlternateSolutionsFile` does.
+
 ### Reproducing a bug found via the C++ test suite
 
 - If a failure was first found through `ModelTest`/the C++ `Problem` API

--- a/misc/FindUno.cmake
+++ b/misc/FindUno.cmake
@@ -1,0 +1,86 @@
+# Try to find the Uno NLP solver (https://github.com/cvanaret/Uno).
+#
+# Uno does not install a CMake package configuration file: its CMakeLists.txt
+# declares "EXPORT UnoTargets" but never calls install(EXPORT ...), so
+# find_package(Uno CONFIG) cannot work. Neither does it install a pkg-config
+# file, so this module locates the library and the installed C API header by
+# hand, in the same spirit as misc/FindCBC.cmake and misc/FindGUROBI.cmake.
+#
+# Uno installs
+#   ${prefix}/lib/libuno.{a,so,dylib}
+#   ${prefix}/include/uno/Uno_C_API.h
+#   ${prefix}/include/uno/uno_int.h
+#
+# Once done, this will define
+#
+#  UNO_FOUND       - system has Uno
+#  UNO_INCLUDE_DIR - the directory containing Uno_C_API.h
+#  UNO_LIBRARY     - the Uno library to link against
+#  UNO_LIBRARIES   - Uno plus the dependencies a static Uno needs
+
+include(FindPackageHandleStandardArgs)
+
+# If UNO_DIR is explicitly set, prioritize it
+if(UNO_DIR)
+    find_path(UNO_INCLUDE_DIR
+              NAMES "Uno_C_API.h"
+              HINTS "${UNO_DIR}/include/uno" "${UNO_DIR}/include"
+              NO_DEFAULT_PATH)
+
+    find_library(UNO_LIBRARY
+                 NAMES uno
+                 HINTS "${UNO_DIR}/lib" "${UNO_DIR}/lib64"
+                 NO_DEFAULT_PATH)
+endif()
+
+# If not found via UNO_DIR, search the standard locations
+if(NOT UNO_INCLUDE_DIR)
+    find_path(UNO_INCLUDE_DIR
+              NAMES "Uno_C_API.h"
+              PATH_SUFFIXES "uno")
+endif()
+
+if(NOT UNO_LIBRARY)
+    find_library(UNO_LIBRARY NAMES uno)
+endif()
+
+set(UNO_LIBRARIES ${UNO_LIBRARY})
+
+# A static Uno does not carry its dependencies, so they have to be repeated on
+# the link line. Uno itself requires BLAS and LAPACK unconditionally, and is
+# partly written in Fortran, so the Fortran runtime is needed as well. For a
+# shared Uno these are already recorded in the library and adding them is
+# harmless.
+if(UNO_LIBRARY AND UNO_LIBRARY MATCHES "\\.a$")
+    find_package(BLAS)
+    find_package(LAPACK)
+
+    if(BLAS_FOUND)
+        list(APPEND UNO_LIBRARIES ${BLAS_LIBRARIES})
+    endif()
+
+    if(LAPACK_FOUND)
+        list(APPEND UNO_LIBRARIES ${LAPACK_LIBRARIES})
+    endif()
+
+    # gfortran is needed for a static Uno built with the GNU Fortran compiler.
+    find_library(UNO_GFORTRAN_LIBRARY NAMES gfortran)
+
+    if(UNO_GFORTRAN_LIBRARY)
+        list(APPEND UNO_LIBRARIES ${UNO_GFORTRAN_LIBRARY})
+    else()
+        message(STATUS "Uno: libgfortran not found; a static Uno may fail to link. "
+                       "Consider building Uno with -DBUILD_SHARED_LIBS=ON.")
+    endif()
+
+    mark_as_advanced(UNO_GFORTRAN_LIBRARY)
+endif()
+
+# Handle the QUIETLY and REQUIRED arguments and set UNO_FOUND to TRUE if all
+# listed variables are TRUE.
+find_package_handle_standard_args(Uno
+                                  DEFAULT_MSG
+                                  UNO_LIBRARY
+                                  UNO_INCLUDE_DIR)
+
+mark_as_advanced(UNO_LIBRARY UNO_INCLUDE_DIR)

--- a/src/Enums.h
+++ b/src/Enums.h
@@ -317,6 +317,20 @@ enum class ES_IpoptSolver
     mumps
 };
 
+enum class ES_UnoPreset
+{
+    UnoAuto,
+    ipopt,
+    filtersqp
+};
+
+enum class ES_UnoHessianModel
+{
+    exact,
+    LBFGS,
+    LSR1
+};
+
 enum class ES_IterationOutputDetail
 {
     Full,
@@ -387,6 +401,7 @@ enum class ES_PrimalNLPSolver
     Ipopt,
     GAMS,
     SHOT,
+    Uno,
     None
 };
 

--- a/src/NLPSolver/NLPSolverUno.cpp
+++ b/src/NLPSolver/NLPSolverUno.cpp
@@ -1,0 +1,846 @@
+/**
+   The Supporting Hyperplane Optimization Toolkit (SHOT).
+
+   @author Andreas Lundell, Åbo Akademi University
+
+   @section LICENSE
+   This software is licensed under the Eclipse Public License 2.0.
+   Please see the README and LICENSE files for more information.
+*/
+
+#include "NLPSolverUno.h"
+
+#include <cmath>
+#include <cstring>
+#include <limits>
+#include <stdexcept>
+
+#include "../Output.h"
+#include "../Settings.h"
+#include "../Utilities.h"
+
+#include "Uno_C_API.h"
+
+namespace SHOT
+{
+
+namespace
+{
+
+    /* Bounds at least this large in magnitude are handed to Uno as actual infinities. Uno considers a bound infinite
+       only when it is an infinity, whereas SHOT uses SHOT_DBL_MIN/SHOT_DBL_MAX. The threshold matches the default of
+       Ipopt's nlp_lower_bound_inf/nlp_upper_bound_inf options, so that a problem is presented to Uno with the same set
+       of variables considered unbounded as it is to Ipopt. */
+    const double UNO_BOUND_INFINITY = 1e19;
+
+    /* Uno passes back the user data registered with uno_set_user_data, which is the NLPSolverUno instance that owns
+    the model. */
+
+    uno_int objectiveCallback(uno_int numberOfVariables, const double* x, double* value, void* userData)
+    {
+        auto* solver = static_cast<NLPSolverUno*>(userData);
+        return (solver->evaluateObjective(numberOfVariables, x, value) ? 0 : 1);
+    }
+
+    uno_int objectiveGradientCallback(uno_int numberOfVariables, const double* x, double* gradient, void* userData)
+    {
+        auto* solver = static_cast<NLPSolverUno*>(userData);
+        return (solver->evaluateObjectiveGradient(numberOfVariables, x, gradient) ? 0 : 1);
+    }
+
+    uno_int constraintsCallback(
+        uno_int numberOfVariables, uno_int numberOfConstraints, const double* x, double* values, void* userData)
+    {
+        auto* solver = static_cast<NLPSolverUno*>(userData);
+        return (solver->evaluateConstraints(numberOfVariables, numberOfConstraints, x, values) ? 0 : 1);
+    }
+
+    uno_int jacobianCallback(
+        uno_int numberOfVariables, uno_int numberOfNonzeros, const double* x, double* values, void* userData)
+    {
+        auto* solver = static_cast<NLPSolverUno*>(userData);
+        return (solver->evaluateJacobian(numberOfVariables, numberOfNonzeros, x, values) ? 0 : 1);
+    }
+
+    uno_int lagrangianHessianCallback(uno_int numberOfVariables, uno_int numberOfConstraints, uno_int numberOfNonzeros,
+        const double* x, double objectiveMultiplier, const double* multipliers, double* values, void* userData)
+    {
+        auto* solver = static_cast<NLPSolverUno*>(userData);
+        return (solver->evaluateLagrangianHessian(numberOfVariables, numberOfConstraints, numberOfNonzeros, x,
+                    objectiveMultiplier, multipliers, values)
+                ? 0
+                : 1);
+    }
+
+    uno_int loggerCallback(const char* buffer, uno_int length, void* userData)
+    {
+        auto* solver = static_cast<NLPSolverUno*>(userData);
+        solver->writeLoggerOutput(buffer, length);
+        return (0);
+    }
+
+    /* Uno's logger stream is registered per process rather than per solver, while SHOT can have more than one
+       NLPSolverUno alive at a time (the solution strategies create a fixed-integer NLP task both for the search and for
+       the final polish). The most recent registration is the one in effect, so it is tracked here to keep a solver that
+       is destroyed from tearing down another solver's logging. */
+    NLPSolverUno* activeLoggerOwner = nullptr;
+
+} // namespace
+
+double NLPSolverUno::toUnoBound(double bound)
+{
+    if(bound >= UNO_BOUND_INFINITY)
+        return (std::numeric_limits<double>::infinity());
+
+    if(bound <= -UNO_BOUND_INFINITY)
+        return (-std::numeric_limits<double>::infinity());
+
+    return (bound);
+}
+
+NLPSolverUno::NLPSolverUno(EnvironmentPtr envPtr, ProblemPtr source) : INLPSolver(envPtr)
+{
+    sourceProblem = source;
+
+    lowerBounds = sourceProblem->getVariableLowerBounds();
+    upperBounds = sourceProblem->getVariableUpperBounds();
+
+    variableSolution.resize(sourceProblem->properties.numberOfVariables);
+
+    unoSolver = uno_create_solver();
+
+    if(unoSolver == nullptr)
+        throw std::runtime_error("Could not create Uno solver.");
+
+    /* The logger stream is registered globally in Uno rather than per solver, so it is set here and released again
+       in the destructor. It plays the same role as IpoptJournal does for Ipopt. */
+    uno_set_logger_stream_callback(loggerCallback, this);
+    activeLoggerOwner = this;
+
+    createModel();
+    setInitialSettings();
+
+    uno_int major = 0;
+    uno_int minor = 0;
+    uno_int patch = 0;
+    uno_get_version(&major, &minor, &patch);
+
+    std::string preset;
+
+    switch(static_cast<ES_UnoPreset>(env->settings->getSetting<int>("Subsolver.Uno.Preset")))
+    {
+    case(ES_UnoPreset::ipopt):
+        preset = "Ipopt preset";
+        break;
+
+    case(ES_UnoPreset::filtersqp):
+        preset = "filterSQP preset";
+        break;
+
+    default:
+        preset = "automatically selected preset";
+        break;
+    }
+
+    /* uno_get_method_description() only describes a strategy that has actually been built, so it is not meaningful
+       until the first solve. This is called by TaskSelectPrimalCandidatesFromNLP before any solve, so the
+       configured preset is reported instead. */
+    solverDescription = fmt::format("Uno {}.{}.{} (with the {})", major, minor, patch, preset);
+}
+
+NLPSolverUno::~NLPSolverUno()
+{
+    /* Released unconditionally. Uno's logger stream is registered per process, so leaving it in place once any
+       solver goes away risks the callback being invoked with a solver, or an environment, that no longer exists,
+       which crashes during teardown. Releasing it early only means that a second, still-live solver stops writing
+       to the log, which is preferable. */
+    uno_reset_logger_stream();
+
+    if(activeLoggerOwner == this)
+        activeLoggerOwner = nullptr;
+
+    if(unoModel != nullptr)
+        uno_destroy_model(unoModel);
+
+    if(unoSolver != nullptr)
+        uno_destroy_solver(unoSolver);
+}
+
+void NLPSolverUno::createModel()
+{
+    int numberOfVariables = sourceProblem->properties.numberOfVariables;
+    int numberOfConstraints = sourceProblem->properties.numberOfNumericConstraints;
+
+    VectorDouble variableLowerBounds(numberOfVariables);
+    VectorDouble variableUpperBounds(numberOfVariables);
+
+    for(int i = 0; i < numberOfVariables; i++)
+    {
+        variableLowerBounds[i] = toUnoBound(lowerBounds[i]);
+        variableUpperBounds[i] = toUnoBound(upperBounds[i]);
+    }
+
+    unoModel = uno_create_model(UNO_PROBLEM_NONLINEAR, numberOfVariables, variableLowerBounds.data(),
+        variableUpperBounds.data(), UNO_ZERO_BASED_INDEXING);
+
+    if(unoModel == nullptr)
+        throw std::runtime_error("Could not create Uno model.");
+
+    uno_set_model_name(unoModel, sourceProblem->name.c_str());
+    uno_set_user_data(unoModel, this);
+
+    uno_set_objective(unoModel, sourceProblem->objectiveFunction->properties.isMinimize ? UNO_MINIMIZE : UNO_MAXIMIZE,
+        objectiveCallback, objectiveGradientCallback);
+
+    /* SHOT accumulates the Lagrangian Hessian as obj_factor*d2f + sum(lambda_i*d2c_i), i.e. with positive
+       multipliers, which is the opposite of Uno's default convention. Declaring the convention makes Uno flip the
+       multipliers before handing them to the Hessian callback; without this the Hessian is silently wrong. */
+    uno_set_lagrangian_sign_convention(unoModel, UNO_MULTIPLIER_POSITIVE);
+
+    /* Unlike Ipopt, Uno takes the sparsity patterns once when the model is defined rather than through a structure
+       pass of the evaluation callbacks, so both patterns and the maps from an entry to its position in the value
+       array are built here and then reused by every evaluation. */
+
+    VectorDouble constraintLowerBounds(numberOfConstraints);
+    VectorDouble constraintUpperBounds(numberOfConstraints);
+
+    for(int i = 0; i < numberOfConstraints; i++)
+    {
+        auto constraint = sourceProblem->numericConstraints[i];
+
+        constraintLowerBounds[i] = toUnoBound(constraint->valueLHS);
+        constraintUpperBounds[i] = toUnoBound(constraint->valueRHS);
+    }
+
+    std::vector<uno_int> jacobianRows;
+    std::vector<uno_int> jacobianColumns;
+
+    jacobianCounterPlacement.clear();
+
+    for(auto& C : sourceProblem->numericConstraints)
+    {
+        for(auto& G : *C->getGradientSparsityPattern())
+        {
+            jacobianCounterPlacement.emplace(
+                std::make_pair(C->getIndex(), G->getIndex()), static_cast<int>(jacobianRows.size()));
+
+            jacobianRows.push_back(C->getIndex());
+            jacobianColumns.push_back(G->getIndex());
+        }
+    }
+
+    numberOfJacobianNonzeros = static_cast<int>(jacobianRows.size());
+
+    uno_set_constraints(unoModel, numberOfConstraints, constraintsCallback, constraintLowerBounds.data(),
+        constraintUpperBounds.data(), numberOfJacobianNonzeros, jacobianRows.data(), jacobianColumns.data(),
+        jacobianCallback);
+
+    std::vector<uno_int> hessianRows;
+    std::vector<uno_int> hessianColumns;
+
+    lagrangianHessianCounterPlacement.clear();
+
+    for(auto& E : *sourceProblem->getLagrangianHessianSparsityPattern())
+    {
+        assert(E.first->getIndex() <= E.second->getIndex());
+
+        lagrangianHessianCounterPlacement.emplace(
+            std::make_pair(E.first->getIndex(), E.second->getIndex()), static_cast<int>(hessianRows.size()));
+
+        hessianRows.push_back(E.first->getIndex());
+        hessianColumns.push_back(E.second->getIndex());
+    }
+
+    numberOfHessianNonzeros = static_cast<int>(hessianRows.size());
+
+    /* SHOT's Lagrangian Hessian sparsity pattern is stored with the row index not exceeding the column index, so
+       it is the upper triangle that is provided. Uno transposes it into its own storage. */
+    uno_set_lagrangian_hessian(unoModel, numberOfHessianNonzeros, UNO_UPPER_TRIANGLE, hessianRows.data(),
+        hessianColumns.data(), lagrangianHessianCallback);
+
+    // Uno copies the bounds and the sparsity patterns, so the local arrays do not need to be kept alive.
+}
+
+void NLPSolverUno::setInitialSettings()
+{
+    /* A preset must always be selected explicitly, and it is applied first since it assigns whole groups of
+       options that the settings below then override individually.
+
+       Uno resolves its own "auto" preset only inside uno_optimize, and by then it has already been overridden:
+       uno_create_solver() preloads every default option, and uno_optimize() lets those defaults overwrite the
+       preset it just picked. The defaults combine an SQP method with inertia correction, which needs a symmetric
+       indefinite linear solver, so on a build without one every solve fails with an algorithmic error. Calling
+       uno_set_solver_preset() is what puts the preset values among the options that win, but it rejects "auto"
+       because that choice depends on the model. The size rule Uno uses for "auto" is therefore applied here. */
+    auto preset = static_cast<ES_UnoPreset>(env->settings->getSetting<int>("Subsolver.Uno.Preset"));
+
+    if(preset == ES_UnoPreset::UnoAuto)
+    {
+        int size = sourceProblem->properties.numberOfVariables + sourceProblem->properties.numberOfNumericConstraints;
+        int nonzeros = numberOfJacobianNonzeros + numberOfHessianNonzeros;
+
+        preset = (size >= 2000 || nonzeros >= 50000) ? ES_UnoPreset::ipopt : ES_UnoPreset::filtersqp;
+    }
+
+    uno_set_solver_preset(unoSolver, preset == ES_UnoPreset::ipopt ? "ipopt" : "filtersqp");
+
+    uno_set_solver_double_option(
+        unoSolver, "primal_tolerance", env->settings->getSetting<double>("Subsolver.Uno.ConstraintViolationTolerance"));
+
+    uno_set_solver_double_option(
+        unoSolver, "dual_tolerance", env->settings->getSetting<double>("Subsolver.Uno.RelativeConvergenceTolerance"));
+
+    uno_set_solver_integer_option(
+        unoSolver, "max_iterations", env->settings->getSetting<int>("Subsolver.Uno.MaxIterations"));
+
+    uno_set_solver_double_option(
+        unoSolver, "time_limit", env->settings->getSetting<double>("Primal.FixedInteger.TimeLimit"));
+
+    switch(static_cast<ES_UnoHessianModel>(env->settings->getSetting<int>("Subsolver.Uno.HessianModel")))
+    {
+    case(ES_UnoHessianModel::LBFGS):
+        uno_set_solver_string_option(unoSolver, "hessian_model", "LBFGS");
+        break;
+
+    case(ES_UnoHessianModel::LSR1):
+        uno_set_solver_string_option(unoSolver, "hessian_model", "LSR1");
+        break;
+
+    case(ES_UnoHessianModel::exact):
+    default:
+        uno_set_solver_string_option(unoSolver, "hessian_model", "exact");
+        break;
+    }
+
+    /* Uno warns once per fixed variable each time a model is solved, and SHOT fixes every discrete variable on
+       every call, so the log has to be quietened rather than only redirected. */
+    uno_set_solver_string_option(
+        unoSolver, "logger", env->settings->getSetting<bool>("Output.Console.PrimalSolver.Show") ? "INFO" : "SILENT");
+
+    /* Read last so that an option set explicitly by the user takes precedence over the ones derived from the SHOT
+       settings above. */
+    auto optionsFile = env->settings->getSetting<std::string>("Subsolver.Uno.OptionsFile");
+
+    if(optionsFile != "")
+    {
+        if(!uno_load_solver_option_file(unoSolver, optionsFile.c_str()))
+            env->output->outputWarning("        Could not read the Uno option file " + optionsFile + ".");
+    }
+}
+
+void NLPSolverUno::pushBoundsToModel()
+{
+    int numberOfVariables = sourceProblem->properties.numberOfVariables;
+
+    VectorDouble variableLowerBounds(numberOfVariables);
+    VectorDouble variableUpperBounds(numberOfVariables);
+
+    for(int i = 0; i < numberOfVariables; i++)
+    {
+        variableLowerBounds[i] = toUnoBound(lowerBounds[i]);
+        variableUpperBounds[i] = toUnoBound(upperBounds[i]);
+    }
+
+    uno_set_variables_lower_bounds(unoModel, variableLowerBounds.data());
+    uno_set_variables_upper_bounds(unoModel, variableUpperBounds.data());
+}
+
+void NLPSolverUno::pushStartingPointToModel()
+{
+    int numberOfVariables = sourceProblem->properties.numberOfVariables;
+
+    VectorDouble startingPoint(numberOfVariables);
+    std::vector<bool> isInitialized(numberOfVariables, false);
+
+    for(size_t k = 0; k < startingPointVariableIndexes.size(); k++)
+    {
+        int variableIndex = startingPointVariableIndexes[k];
+        double variableValue = startingPointVariableValues[k];
+
+        double variableLB = sourceProblem->getVariableLowerBound(variableIndex);
+        double variableUB = sourceProblem->getVariableUpperBound(variableIndex);
+
+        if(variableUB == SHOT_DBL_MAX)
+        {
+            if(variableValue < variableLB)
+            {
+                env->output->outputDebug("         Initial value " + std::to_string(variableValue)
+                    + " for variable with index " + std::to_string(variableIndex) + " is less than the lower bound "
+                    + std::to_string(variableLB));
+                continue;
+            }
+        }
+        else if(variableLB == SHOT_DBL_MIN)
+        {
+            if(variableValue > variableUB)
+            {
+                env->output->outputDebug("         Initial value " + std::to_string(variableValue)
+                    + " for variable with index " + std::to_string(variableIndex) + " is larger than the upper bound "
+                    + std::to_string(variableUB));
+                continue;
+            }
+        }
+        else
+        {
+            if(variableValue < variableLB || variableValue > variableUB)
+            {
+                env->output->outputDebug("         Initial value " + std::to_string(variableValue)
+                    + " for variable with index " + std::to_string(variableIndex) + " is not within variable bounds ["
+                    + std::to_string(variableLB) + "," + std::to_string(variableUB));
+                continue;
+            }
+        }
+
+        if(variableValue < -divergingIterativesTolerance)
+            variableValue = -0.99 * divergingIterativesTolerance;
+        else if(variableValue > divergingIterativesTolerance)
+            variableValue = 0.99 * divergingIterativesTolerance;
+
+        startingPoint[variableIndex] = variableValue;
+        isInitialized[variableIndex] = true;
+    }
+
+    double defaultInitValue = 1.7171;
+
+    for(int k = 0; k < numberOfVariables; k++)
+    {
+        if(isInitialized[k])
+            continue;
+
+        double variableLB = sourceProblem->getVariableLowerBound(k);
+        double variableUB = sourceProblem->getVariableUpperBound(k);
+
+        if(variableUB == SHOT_DBL_MAX)
+            startingPoint[k] = (defaultInitValue > variableLB) ? defaultInitValue : variableLB;
+        else if(variableLB == SHOT_DBL_MIN)
+            startingPoint[k] = (defaultInitValue < variableUB) ? defaultInitValue : variableUB;
+        else if(variableLB <= defaultInitValue && defaultInitValue <= variableUB)
+            startingPoint[k] = defaultInitValue;
+        else if(variableLB > defaultInitValue)
+            startingPoint[k] = variableLB;
+        else
+            startingPoint[k] = variableUB;
+    }
+
+    uno_set_initial_primal_iterate(unoModel, startingPoint.data());
+}
+
+bool NLPSolverUno::evaluateObjective(int numberOfVariables, const double* x, double* value)
+{
+    VectorDouble vectorPoint(x, x + numberOfVariables);
+
+    *value = sourceProblem->objectiveFunction->calculateValue(vectorPoint);
+
+    return (true);
+}
+
+bool NLPSolverUno::evaluateObjectiveGradient(int numberOfVariables, const double* x, double* gradient)
+{
+    VectorDouble vectorPoint(x, x + numberOfVariables);
+
+    std::memset(gradient, 0, numberOfVariables * sizeof(double));
+
+    for(auto& G : sourceProblem->objectiveFunction->calculateGradient(vectorPoint, false))
+        gradient[G.first->getIndex()] = G.second;
+
+    return (true);
+}
+
+bool NLPSolverUno::evaluateConstraints(int numberOfVariables, int numberOfConstraints, const double* x, double* values)
+{
+    VectorDouble vectorPoint(x, x + numberOfVariables);
+
+    for(int i = 0; i < numberOfConstraints; i++)
+        values[i] = sourceProblem->numericConstraints[i]->calculateFunctionValue(vectorPoint);
+
+    return (true);
+}
+
+bool NLPSolverUno::evaluateJacobian(int numberOfVariables, int numberOfNonzeros, const double* x, double* values)
+{
+    VectorDouble vectorPoint(x, x + numberOfVariables);
+
+    std::memset(values, 0, numberOfNonzeros * sizeof(double));
+
+    for(auto& C : sourceProblem->numericConstraints)
+    {
+        for(auto& G : C->calculateGradient(vectorPoint, false))
+        {
+            int location = jacobianCounterPlacement[std::make_pair(C->getIndex(), G.first->getIndex())];
+
+            assert(location < numberOfNonzeros);
+            assert(location >= 0);
+
+            values[location] += G.second;
+        }
+    }
+
+    return (true);
+}
+
+bool NLPSolverUno::evaluateLagrangianHessian(int numberOfVariables, [[maybe_unused]] int numberOfConstraints,
+    int numberOfNonzeros, const double* x, double objectiveMultiplier, const double* multipliers, double* values)
+{
+    VectorDouble vectorPoint(x, x + numberOfVariables);
+
+    std::memset(values, 0, numberOfNonzeros * sizeof(double));
+
+    if(objectiveMultiplier != 0.0)
+    {
+        for(auto& E : sourceProblem->objectiveFunction->calculateHessian(vectorPoint, false))
+        {
+            int location = lagrangianHessianCounterPlacement[std::make_pair(
+                E.first.first->getIndex(), E.first.second->getIndex())];
+
+            assert(location < numberOfNonzeros);
+            assert(location >= 0);
+
+            values[location] = objectiveMultiplier * E.second;
+        }
+    }
+
+    for(auto& C : sourceProblem->numericConstraints)
+    {
+        if(C->properties.classification == E_ConstraintClassification::Linear)
+            continue;
+
+        if(multipliers[C->getIndex()] == 0.0)
+            continue;
+
+        for(auto& E : C->calculateHessian(vectorPoint, false))
+        {
+            int location = lagrangianHessianCounterPlacement[std::make_pair(
+                E.first.first->getIndex(), E.first.second->getIndex())];
+
+            assert(location < numberOfNonzeros);
+            assert(location >= 0);
+
+            values[location] += multipliers[C->getIndex()] * E.second;
+        }
+    }
+
+    return (true);
+}
+
+void NLPSolverUno::writeLoggerOutput(const char* buffer, int length)
+{
+    /* Releasing Uno's logger stream deletes the stream object, which flushes whatever it still holds and therefore
+       calls back in here. That happens from the destructor, by which point the environment this solver was created
+       with may already be gone, so there is nothing left to write to. */
+    if(!env || !env->output)
+    {
+        loggerBuffer.clear();
+        return;
+    }
+
+    /* Uno writes its output in pieces that do not line up with line boundaries, so the text is buffered here and
+       only forwarded once a newline has been seen. Otherwise a message that Uno emits without a trailing newline,
+       such as the reason it stopped, is split across calls and lost. */
+    loggerBuffer.append(buffer, length);
+
+    size_t lineEnd;
+
+    while((lineEnd = loggerBuffer.find('\n')) != std::string::npos)
+    {
+        std::string line = loggerBuffer.substr(0, lineEnd);
+        loggerBuffer.erase(0, lineEnd + 1);
+
+        if(line != "")
+            env->output->outputInfo("      | " + line);
+    }
+}
+
+void NLPSolverUno::flushLoggerOutput()
+{
+    if(loggerBuffer != "")
+        env->output->outputInfo("      | " + loggerBuffer);
+
+    loggerBuffer.clear();
+}
+
+E_NLPSolutionStatus NLPSolverUno::solveProblemInstance()
+{
+    env->output->outputDebug("        Starting solution of Uno problem.");
+
+    E_NLPSolutionStatus status;
+
+    variableSolution.clear();
+    variableSolution.resize(sourceProblem->properties.numberOfVariables);
+    objectiveValue = 0.0;
+
+    try
+    {
+        pushBoundsToModel();
+        pushStartingPointToModel();
+
+        uno_optimize(unoSolver, unoModel);
+
+        // Uno's last message may not end in a newline, so make sure it is not left sitting in the buffer
+        flushLoggerOutput();
+
+        uno_int optimizationStatus = uno_get_optimization_status(unoSolver);
+
+        if(optimizationStatus == UNO_ITERATION_LIMIT)
+        {
+            status = E_NLPSolutionStatus::IterationLimit;
+            env->output->outputDebug("        No solution found to problem with Uno: Iteration limit exceeded.");
+        }
+        else if(optimizationStatus == UNO_TIME_LIMIT)
+        {
+            status = E_NLPSolutionStatus::TimeLimit;
+            env->output->outputDebug("        No solution found to problem with Uno: Time limit exceeded.");
+        }
+        else if(optimizationStatus != UNO_SUCCESS)
+        {
+            status = E_NLPSolutionStatus::Error;
+
+            std::string reason;
+
+            if(optimizationStatus == UNO_EVALUATION_ERROR)
+                reason = "a function evaluation failed";
+            else if(optimizationStatus == UNO_ALGORITHMIC_ERROR)
+                reason = "of an algorithmic error";
+            else if(optimizationStatus == UNO_USER_TERMINATION)
+                reason = "the solve was terminated";
+            else
+                reason = fmt::format("of an unknown optimization status {}", optimizationStatus);
+
+            env->output->outputDebug(
+                fmt::format("        Error when solving NLP problem with Uno: {} (solution status {}).", reason,
+                    uno_get_solution_status(unoSolver)));
+        }
+        else
+        {
+            /* Uno reports the reason it stopped separately from the quality of the point it stopped at, so the
+               solution status decides what the point can be used for. */
+            uno_int solutionStatus = uno_get_solution_status(unoSolver);
+
+            if(solutionStatus == UNO_FEASIBLE_KKT_POINT)
+            {
+                status = E_NLPSolutionStatus::Optimal;
+                env->output->outputDebug("        Local solution found with Uno.");
+            }
+            else if(solutionStatus == UNO_FEASIBLE_FJ_POINT || solutionStatus == UNO_FEASIBLE_SMALL_STEP)
+            {
+                status = E_NLPSolutionStatus::Feasible;
+                env->output->outputDebug("        Feasible solution found with Uno.");
+            }
+            else if(solutionStatus == UNO_INFEASIBLE_STATIONARY_POINT || solutionStatus == UNO_INFEASIBLE_SMALL_STEP)
+            {
+                status = E_NLPSolutionStatus::Infeasible;
+                env->output->outputDebug("        No solution found to problem with Uno: Locally infeasible.");
+            }
+            else if(solutionStatus == UNO_DIVERGING_ITERATE || solutionStatus == UNO_UNBOUNDED_OBJECTIVE)
+            {
+                status = E_NLPSolutionStatus::Unbounded;
+                env->output->outputDebug("        No solution found to problem with Uno: Diverging iterates.");
+            }
+            else
+            {
+                status = E_NLPSolutionStatus::Error;
+                env->output->outputDebug("        No solution found to problem with Uno.");
+            }
+        }
+
+        /* The result is held by the solver rather than the model, so it is copied out before anything else can be
+           solved. Uno converts the objective back into the sense of the model, so no sign correction is needed. */
+        if(status != E_NLPSolutionStatus::Error)
+        {
+            uno_get_primal_solution(unoSolver, variableSolution.data());
+            objectiveValue = uno_get_solution_objective(unoSolver);
+        }
+    }
+    catch(std::exception& e)
+    {
+        /* Uno throws when a requested subproblem solver was not compiled into it, and uno_optimize does not catch
+           it, so the exception surfaces here. */
+        env->output->outputError("        Error when solving problem with Uno!", e.what());
+        status = E_NLPSolutionStatus::Error;
+    }
+    catch(...)
+    {
+        env->output->outputError("        Unspecified error when solving problem with Uno!");
+        status = E_NLPSolutionStatus::Error;
+    }
+
+    env->output->outputDebug("        Finished solution of Uno problem.");
+
+    return (status);
+}
+
+void NLPSolverUno::setStartingPoint(VectorInteger variableIndexes, VectorDouble variableValues)
+{
+    startingPointVariableIndexes = variableIndexes;
+    startingPointVariableValues = variableValues;
+
+    int startingPointSize = startingPointVariableIndexes.size();
+
+    if(startingPointSize == 0)
+        return;
+
+    env->output->outputDebug("        Adding starting points to Uno.");
+
+    for(int k = 0; k < startingPointSize; k++)
+    {
+        int currVarIndex = startingPointVariableIndexes.at(k);
+        auto currPt = startingPointVariableValues.at(k);
+
+        auto currLB = sourceProblem->getVariableLowerBound(currVarIndex);
+        auto currUB = sourceProblem->getVariableUpperBound(currVarIndex);
+
+        if(currPt > currUB)
+        {
+            env->output->outputDebug("         Starting point value for variable " + std::to_string(currVarIndex)
+                + " is larger than ub: " + Utilities::toString(currPt) + " > " + Utilities::toString(currUB)
+                + "; resetting to ub.");
+
+            if(currUB == 1 && currPt > 1 && currPt < 1.00001)
+                currPt = 1;
+            else
+                currPt = currUB;
+        }
+
+        if(currPt < currLB)
+        {
+            env->output->outputDebug("         Starting point value for variable " + std::to_string(currVarIndex)
+                + " is smaller than lb: " + Utilities::toString(currPt) + " < " + Utilities::toString(currLB)
+                + "; resetting to lb.");
+
+            if(currLB == 0 && currPt < 0 && currPt > -0.00001)
+                currPt = 0;
+            else
+                currPt = currLB;
+        }
+
+        startingPointVariableValues.at(k) = currPt;
+    }
+
+    env->output->outputDebug("        All starting points set.");
+}
+
+void NLPSolverUno::clearStartingPoint()
+{
+    startingPointVariableIndexes.clear();
+    startingPointVariableValues.clear();
+    setInitialSettings();
+}
+
+void NLPSolverUno::fixVariables(VectorInteger variableIndexes, VectorDouble variableValues)
+{
+    fixedVariableIndexes = variableIndexes;
+    fixedVariableValues = variableValues;
+
+    int size = fixedVariableIndexes.size();
+
+    if(size == 0)
+        return;
+
+    if(lowerBoundsBeforeFix.size() > 0 || upperBoundsBeforeFix.size() > 0)
+    {
+        env->output->outputDebug("        Old variable fixes remain for Uno solver, resetting!");
+        lowerBoundsBeforeFix.clear();
+        upperBoundsBeforeFix.clear();
+    }
+
+    env->output->outputDebug("        Defining fixed variables in Uno.");
+
+    for(int k = 0; k < size; k++)
+    {
+        int currVarIndex = fixedVariableIndexes.at(k);
+        double currPt = fixedVariableValues.at(k);
+
+        double currLB = sourceProblem->getVariableLowerBound(currVarIndex);
+        double currUB = sourceProblem->getVariableUpperBound(currVarIndex);
+
+        lowerBoundsBeforeFix.push_back(currLB);
+        upperBoundsBeforeFix.push_back(currUB);
+
+        currPt = std::round(currPt);
+
+        // Fix for negative zero
+        if(currPt >= (0.0 - std::numeric_limits<double>::epsilon())
+            && currPt <= 0.0 + std::numeric_limits<double>::epsilon())
+        {
+            currPt = 0.0;
+        }
+
+        if(currPt > currUB)
+        {
+            env->output->outputDebug("         Fixed value for variable " + std::to_string(currVarIndex)
+                + " is larger than ub: " + Utilities::toString(currPt) + " > " + std::to_string(currUB));
+
+            if(currUB == 1 && currPt > 1 && currPt < 1.00001)
+                currPt = 1;
+            else
+                continue;
+        }
+        else if(currPt < currLB)
+        {
+            env->output->outputDebug("         Fixed value for variable " + std::to_string(currVarIndex)
+                + " is smaller than lb: " + Utilities::toString(currPt) + " < " + std::to_string(currLB));
+
+            if(currLB == 0 && currPt < 0 && currPt > -0.00001)
+                currPt = 0;
+            else
+                continue;
+        }
+
+        if(currPt >= currLB && currPt <= currUB)
+        {
+            lowerBounds.at(currVarIndex) = currPt;
+            upperBounds.at(currVarIndex) = currPt;
+        }
+        else
+        {
+            env->output->outputDebug("          Cannot fix variable value for variable with index "
+                + std::to_string(currVarIndex) + ": not within bounds (" + Utilities::toString(currLB) + " < "
+                + Utilities::toString(currPt) + " < " + Utilities::toString(currUB));
+        }
+    }
+
+    env->output->outputDebug("        All fixed variables defined.");
+}
+
+void NLPSolverUno::unfixVariables()
+{
+    env->output->outputDebug("        Starting reset of fixed variables in Uno.");
+
+    for(size_t k = 0; k < fixedVariableIndexes.size(); k++)
+    {
+        int currVarIndex = fixedVariableIndexes.at(k);
+
+        lowerBounds[currVarIndex] = lowerBoundsBeforeFix.at(k);
+        upperBounds[currVarIndex] = upperBoundsBeforeFix.at(k);
+    }
+
+    fixedVariableIndexes.clear();
+    fixedVariableValues.clear();
+    lowerBoundsBeforeFix.clear();
+    upperBoundsBeforeFix.clear();
+
+    setInitialSettings();
+
+    env->output->outputDebug("        Reset of fixed variables in Uno completed.");
+}
+
+VectorDouble NLPSolverUno::getVariableLowerBounds() { return (lowerBounds); }
+
+VectorDouble NLPSolverUno::getVariableUpperBounds() { return (upperBounds); }
+
+void NLPSolverUno::updateVariableLowerBound(int variableIndex, double bound) { lowerBounds[variableIndex] = bound; }
+
+void NLPSolverUno::updateVariableUpperBound(int variableIndex, double bound) { upperBounds[variableIndex] = bound; }
+
+VectorDouble NLPSolverUno::getSolution() { return (variableSolution); }
+
+double NLPSolverUno::getSolution(int i) { return (variableSolution[i]); }
+
+double NLPSolverUno::getObjectiveValue() { return (objectiveValue); }
+
+void NLPSolverUno::saveOptionsToFile([[maybe_unused]] std::string fileName) { }
+
+void NLPSolverUno::saveProblemToFile([[maybe_unused]] std::string fileName) { }
+
+std::string NLPSolverUno::getSolverDescription() { return (solverDescription); }
+
+} // namespace SHOT

--- a/src/NLPSolver/NLPSolverUno.h
+++ b/src/NLPSolver/NLPSolverUno.h
@@ -1,0 +1,125 @@
+/**
+   The Supporting Hyperplane Optimization Toolkit (SHOT).
+
+   @author Andreas Lundell, Åbo Akademi University
+
+   @section LICENSE
+   This software is licensed under the Eclipse Public License 2.0.
+   Please see the README and LICENSE files for more information.
+*/
+
+#pragma once
+#include "NLPSolverBase.h"
+
+#include "../Model/Problem.h"
+
+#include <map>
+#include <string>
+#include <utility>
+
+namespace SHOT
+{
+
+/**
+   An NLP solver using Uno (https://github.com/cvanaret/Uno) through its C API.
+
+   Uno bundles several NLP algorithms (interior point and SQP) behind a common option set, so which method is
+   actually run is decided by the Subsolver.Uno.Preset setting rather than by the class.
+
+   No Uno header is included here on purpose: the two handles below are kept opaque so that every Uno call stays
+   inside NLPSolverUno.cpp. Should Uno gain a supported C++ interface later, only that file needs to change.
+*/
+class NLPSolverUno : public NLPSolverBase
+{
+private:
+    ProblemPtr sourceProblem;
+
+    void* unoModel = nullptr;
+    void* unoSolver = nullptr;
+
+    VectorDouble lowerBounds;
+    VectorDouble upperBounds;
+
+    VectorDouble lowerBoundsBeforeFix;
+    VectorDouble upperBoundsBeforeFix;
+
+    VectorInteger fixedVariableIndexes;
+    VectorDouble fixedVariableValues;
+
+    VectorInteger startingPointVariableIndexes;
+    VectorDouble startingPointVariableValues;
+
+    VectorDouble variableSolution;
+    double objectiveValue = 0.0;
+
+    /* Maps a (constraint index, variable index) pair onto its position in the Jacobian value array, and a
+       (variable index, variable index) pair onto its position in the Lagrangian Hessian value array. Unlike Ipopt,
+       Uno is given the sparsity pattern once when the model is created rather than through a structure pass of the
+       evaluation callback, so these are built in the constructor and then reused by every evaluation. */
+    std::map<std::pair<int, int>, int> jacobianCounterPlacement;
+    std::map<std::pair<int, int>, int> lagrangianHessianCounterPlacement;
+
+    int numberOfJacobianNonzeros = 0;
+    int numberOfHessianNonzeros = 0;
+
+    std::string solverDescription;
+
+    // Holds the part of Uno's output that has not yet been terminated by a newline
+    std::string loggerBuffer;
+
+    double divergingIterativesTolerance = 1e20;
+
+    void createModel();
+    void setInitialSettings();
+    void pushBoundsToModel();
+    void pushStartingPointToModel();
+
+    /* Uno interprets a bound as unbounded only when it is an actual infinity, whereas SHOT uses SHOT_DBL_MIN and
+       SHOT_DBL_MAX. Passing those through unchanged would make every variable look bounded, which in particular
+       makes the barrier methods place slack terms on bounds of magnitude 1e308. */
+    static double toUnoBound(double bound);
+
+public:
+    NLPSolverUno(EnvironmentPtr envPtr, ProblemPtr source);
+
+    ~NLPSolverUno() override;
+
+    void setStartingPoint(VectorInteger variableIndexes, VectorDouble variableValues) override;
+    void clearStartingPoint() override;
+
+    void fixVariables(VectorInteger variableIndexes, VectorDouble variableValues) override;
+
+    void unfixVariables() override;
+
+    void saveOptionsToFile(std::string fileName) override;
+
+    void saveProblemToFile(std::string fileName) override;
+
+    VectorDouble getSolution() override;
+    double getSolution(int i) override;
+
+    double getObjectiveValue() override;
+
+    void updateVariableLowerBound(int variableIndex, double bound) override;
+    void updateVariableUpperBound(int variableIndex, double bound) override;
+
+    std::string getSolverDescription() override;
+
+    /* The following are called from the Uno callbacks in NLPSolverUno.cpp. They are public only so that the
+       file-static trampolines that Uno is given can reach them; they are not part of the INLPSolver interface. */
+    bool evaluateObjective(int numberOfVariables, const double* x, double* value);
+    bool evaluateObjectiveGradient(int numberOfVariables, const double* x, double* gradient);
+    bool evaluateConstraints(int numberOfVariables, int numberOfConstraints, const double* x, double* values);
+    bool evaluateJacobian(int numberOfVariables, int numberOfNonzeros, const double* x, double* values);
+    bool evaluateLagrangianHessian(int numberOfVariables, int numberOfConstraints, int numberOfNonzeros,
+        const double* x, double objectiveMultiplier, const double* multipliers, double* values);
+    void writeLoggerOutput(const char* buffer, int length);
+    void flushLoggerOutput();
+
+protected:
+    E_NLPSolutionStatus solveProblemInstance() override;
+
+    VectorDouble getVariableLowerBounds() override;
+    VectorDouble getVariableUpperBounds() override;
+};
+} // namespace SHOT

--- a/src/Results.cpp
+++ b/src/Results.cpp
@@ -1221,6 +1221,12 @@ std::string Results::getResultsTrace()
     case(ES_PrimalNLPSolver::Ipopt):
         ss << "Ipopt";
         break;
+    case(ES_PrimalNLPSolver::SHOT):
+        ss << "SHOT";
+        break;
+    case(ES_PrimalNLPSolver::Uno):
+        ss << "Uno";
+        break;
     default:
         ss << "NONE";
         break;

--- a/src/Results.cpp
+++ b/src/Results.cpp
@@ -1245,6 +1245,9 @@ std::string Results::getResultsTrace()
     case(ES_MIPSolver::Cbc):
         ss << "CBC";
         break;
+    case(ES_MIPSolver::Highs):
+        ss << "HIGHS";
+        break;
     default:
         ss << "NONE";
         break;

--- a/src/SHOT.cpp
+++ b/src/SHOT.cpp
@@ -140,6 +140,10 @@ int main(int argc, char* argv[])
         env->output->outputCritical("   --nlp=gams               Use primal NLP solver from GAMS");
 #endif
 
+#ifdef HAS_UNO
+        env->output->outputCritical("   --nlp=uno                Sets the primal NLP solver to Uno");
+#endif
+
         env->output->outputCritical("   --nlp=shot               Use SHOT as primal NLP solver");
 
 #ifdef HAS_CPLEX

--- a/src/SHOT.cpp
+++ b/src/SHOT.cpp
@@ -423,6 +423,11 @@ int main(int argc, char* argv[])
             solver.updateSetting(
                 "Primal.FixedInteger.Solver", static_cast<int>(ES_PrimalNLPSolver::Ipopt), E_SettingPriority::UserAPI);
 #endif
+#ifdef HAS_UNO
+        if(argValue == "uno")
+            solver.updateSetting(
+                "Primal.FixedInteger.Solver", static_cast<int>(ES_PrimalNLPSolver::Uno), E_SettingPriority::UserAPI);
+#endif
         if(argValue == "shot")
             solver.updateSetting(
                 "Primal.FixedInteger.Solver", static_cast<int>(ES_PrimalNLPSolver::SHOT), E_SettingPriority::UserAPI);

--- a/src/SHOTpy.cpp
+++ b/src/SHOTpy.cpp
@@ -283,6 +283,7 @@ PYBIND11_MODULE(SHOTpy, m)
         .value("Ipopt", ES_PrimalNLPSolver::Ipopt)
         .value("GAMS", ES_PrimalNLPSolver::GAMS)
         .value("SHOT", ES_PrimalNLPSolver::SHOT)
+        .value("Uno", ES_PrimalNLPSolver::Uno)
         .value("None", ES_PrimalNLPSolver::None);
 
     // NLP solver call strategy

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -1371,6 +1371,7 @@ void Solver::initializeSettings()
     enumPrimalNLPSolver.push_back("Ipopt");
     enumPrimalNLPSolver.push_back("GAMS");
     enumPrimalNLPSolver.push_back("SHOT");
+    enumPrimalNLPSolver.push_back("Uno");
 
     env->settings->createSetting("Primal.FixedInteger.Solver", static_cast<int>(ES_PrimalNLPSolver::Ipopt),
         "NLP solver to use", enumPrimalNLPSolver, 0);
@@ -1403,8 +1404,8 @@ void Solver::initializeSettings()
 
     env->settings->createSetting("Primal.FixedInteger.Warmstart", true, "Warm start the NLP solver");
 
-    env->settings->createSetting("Primal.PolishSolution", true,
-        "Solve an NLP problem from the final solution to try to improve it");
+    env->settings->createSetting(
+        "Primal.PolishSolution", true, "Solve an NLP problem from the final solution to try to improve it");
 
     // Primal settings: rootsearch
 
@@ -1716,6 +1717,43 @@ void Solver::initializeSettings()
 
 #endif
 
+    // Subsolver settings: Uno
+
+#ifdef HAS_UNO
+
+    env->settings->createSettingGroup("Subsolver", "Uno", "Uno", "");
+
+    /* These default to Uno's own tolerances rather than to the tighter ones used for Ipopt. Uno reports an
+       algorithmic error, rather than the point it reached, when it cannot certify stationarity to the requested
+       tolerance, and the accuracy of SHOT's function evaluations does not always allow 1e-8 to be reached. */
+    env->settings->createSetting("Subsolver.Uno.ConstraintViolationTolerance", 1E-6,
+        "Constraint violation tolerance in Uno", SHOT_DBL_MIN, SHOT_DBL_MAX);
+
+    VectorString enumUnoHessianModel;
+    enumUnoHessianModel.push_back("Exact");
+    enumUnoHessianModel.push_back("L-BFGS");
+    enumUnoHessianModel.push_back("L-SR1");
+    env->settings->createSetting("Subsolver.Uno.HessianModel", static_cast<int>(ES_UnoHessianModel::exact),
+        "How Uno models the Hessian", enumUnoHessianModel, 0);
+    enumUnoHessianModel.clear();
+
+    env->settings->createSetting("Subsolver.Uno.MaxIterations", 1000, "Maximum number of iterations");
+
+    env->settings->createSetting(
+        "Subsolver.Uno.OptionsFile", std::string(), "Uno option file to read additional options from");
+
+    VectorString enumUnoPreset;
+    enumUnoPreset.push_back("Automatic");
+    enumUnoPreset.push_back("Ipopt");
+    enumUnoPreset.push_back("filterSQP");
+    env->settings->createSetting(
+        "Subsolver.Uno.Preset", static_cast<int>(ES_UnoPreset::UnoAuto), "The Uno algorithm to use", enumUnoPreset, 0);
+    enumUnoPreset.clear();
+
+    env->settings->createSetting("Subsolver.Uno.RelativeConvergenceTolerance", 1E-6, "Relative convergence tolerance");
+
+#endif
+
     env->settings->createSettingGroup("Subsolver", "SHOT", "SHOT primal NLP solver", "");
 
     env->settings->createSetting(
@@ -1877,6 +1915,15 @@ void Solver::verifySettings()
     }
 #endif
 
+#ifndef HAS_UNO
+    if(static_cast<ES_PrimalNLPSolver>(env->settings->getSetting<int>("Primal.FixedInteger.Solver"))
+        == ES_PrimalNLPSolver::Uno)
+    {
+        env->output->outputWarning(" SHOT has not been compiled with support for the Uno NLP solver.");
+        NLPSolverDefined = false;
+    }
+#endif
+
 #ifdef HAS_GAMS
     if((static_cast<ES_PrimalNLPSolver>(env->settings->getSetting<int>("Primal.FixedInteger.Solver"))
            == ES_PrimalNLPSolver::GAMS)
@@ -1912,6 +1959,11 @@ void Solver::verifySettings()
         env->settings->updateSetting(
             "Primal.FixedInteger.Solver", (int)ES_PrimalNLPSolver::GAMS, E_SettingPriority::SolverCompatibility);
         env->output->outputWarning(" Using GAMS NLP solvers instead.");
+
+#elif HAS_UNO
+        env->settings->updateSetting(
+            "Primal.FixedInteger.Solver", (int)ES_PrimalNLPSolver::Uno, E_SettingPriority::SolverCompatibility);
+        env->output->outputWarning(" Using Uno as NLP solver instead.");
 
 #else
         env->settings->updateSetting(
@@ -2256,6 +2308,9 @@ std::vector<ES_PrimalNLPSolver> Solver::getSupportedNLPSolvers()
 #ifdef HAS_GAMS
     solvers.push_back(ES_PrimalNLPSolver::GAMS);
 #endif
+#ifdef HAS_UNO
+    solvers.push_back(ES_PrimalNLPSolver::Uno);
+#endif
     return solvers;
 }
 
@@ -2323,6 +2378,12 @@ bool Solver::hasNLPSolver(ES_PrimalNLPSolver solver)
 #endif
     case ES_PrimalNLPSolver::GAMS:
 #ifdef HAS_GAMS
+        return true;
+#else
+        return false;
+#endif
+    case ES_PrimalNLPSolver::Uno:
+#ifdef HAS_UNO
         return true;
 #else
         return false;

--- a/src/Tasks/TaskSelectPrimalCandidatesFromNLP.cpp
+++ b/src/Tasks/TaskSelectPrimalCandidatesFromNLP.cpp
@@ -36,6 +36,10 @@
 #include "../ModelingSystem/ModelingSystemGAMS.h"
 #endif
 
+#ifdef HAS_UNO
+#include "../NLPSolver/NLPSolverUno.h"
+#endif
+
 #include "../NLPSolver/NLPSolverSHOT.h"
 
 namespace SHOT
@@ -96,6 +100,38 @@ TaskSelectPrimalCandidatesFromNLP::TaskSelectPrimalCandidatesFromNLP(
         NLPSolver = std::make_shared<NLPSolverGAMS>(env,
             (std::dynamic_pointer_cast<ModelingSystemGAMS>(env->modelingSystem))->modelingObject,
             (std::dynamic_pointer_cast<ModelingSystemGAMS>(env->modelingSystem))->auditLicensing);
+
+        break;
+    }
+#endif
+
+#ifdef HAS_UNO
+    case(ES_PrimalNLPSolver::Uno):
+    {
+        if(useReformulatedProblem)
+        {
+            sourceProblem = env->reformulatedProblem;
+            sourceIsReformulatedProblem = true;
+        }
+        else
+        {
+            sourceProblem = env->problem;
+            sourceIsReformulatedProblem = false;
+        }
+
+        env->results->usedPrimalNLPSolver = ES_PrimalNLPSolver::Uno;
+
+        try
+        {
+            NLPSolver = std::make_shared<NLPSolverUno>(env, sourceProblem);
+        }
+        catch(const std::exception& e)
+        {
+            env->output->outputWarning(fmt::format(
+                " Could not initialize Uno as the fixed-integer NLP solver, disabling this primal heuristic: {}",
+                e.what()));
+            NLPSolver = nullptr;
+        }
 
         break;
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -102,6 +102,11 @@ if(HAS_IPOPT)
   set(Ipopt_parts 1 2)
 endif()
 
+if(HAS_UNO)
+  set(cpptests ${cpptests} Uno)
+  set(Uno_parts 1 2 3)
+endif()
+
 # Instance tests: one case per (MIP solver x NLP solver) combination
 # Format support (.nl, .gms) is checked at runtime; guards here are MIP+NLP only
 set(Instance_parts)

--- a/test/InstanceTestCommon.h
+++ b/test/InstanceTestCommon.h
@@ -424,6 +424,16 @@ static int runInstanceTestMain(int argc, char* argv[], InstanceTestScope scope, 
         std::cout << label << " tests: Cbc + SHOT (NLP)\n";
         passed = runInstanceTests(ES_MIPSolver::Cbc, ES_PrimalNLPSolver::SHOT, verbose, "Cbc + SHOT", scope);
         break;
+#ifdef HAS_UNO
+    case 9:
+        std::cout << label << " tests: HiGHS + Uno\n";
+        passed = runInstanceTests(ES_MIPSolver::Highs, ES_PrimalNLPSolver::Uno, verbose, "HiGHS + Uno", scope);
+        break;
+    case 10:
+        std::cout << label << " tests: Gurobi + Uno\n";
+        passed = runInstanceTests(ES_MIPSolver::Gurobi, ES_PrimalNLPSolver::Uno, verbose, "Gurobi + Uno", scope);
+        break;
+#endif
     default:
         std::cout << "Test #" << choice << " does not exist!\n";
         return -1;

--- a/test/UnoTest.cpp
+++ b/test/UnoTest.cpp
@@ -1,0 +1,379 @@
+/**
+   The Supporting Hyperplane Optimization Toolkit (SHOT).
+
+   @author Andreas Lundell, Åbo Akademi University
+
+   @section LICENSE
+   This software is licensed under the Eclipse Public License 2.0.
+   Please see the README and LICENSE files for more information.
+*/
+
+#include "../src/Solver.h"
+#include "../src/Environment.h"
+#include "../src/Settings.h"
+#include "../src/Timing.h"
+#include "../src/Utilities.h"
+
+#include "../src/Model/Variables.h"
+#include "../src/Model/Terms.h"
+#include "../src/Model/Constraints.h"
+#include "../src/Model/NonlinearExpressions.h"
+#include "../src/Model/Problem.h"
+
+#include "../src/NLPSolver/NLPSolverUno.h"
+
+#ifdef HAS_IPOPT
+#include "../src/NLPSolver/NLPSolverIpoptRelaxed.h"
+#endif
+
+#include <cmath>
+
+using namespace SHOT;
+
+namespace
+{
+
+/* Builds
+ *
+ *     min  (x - 4y)^2
+ *     s.t. x + y == 3
+ *          0.1 <= x <= 2, 0.1 <= y <= 10
+ *
+ * whose solution is x = 2.4, y = 0.6 with objective value 0. Both the objective Hessian and the constraint are
+ * needed to get there, so a Hessian that is wrongly signed or transposed does not reach the optimum.
+ */
+ProblemPtr createMinimizationProblem(EnvironmentPtr env)
+{
+    ProblemPtr problem = std::make_shared<Problem>(env);
+
+    auto var_x = std::make_shared<Variable>("x", E_VariableType::Real, 0.1, 3.0);
+    ExpressionVariablePtr expressionVariable_x = std::make_shared<ExpressionVariable>(var_x);
+
+    auto var_y = std::make_shared<Variable>("y", E_VariableType::Real, 0.1, 10.0);
+    ExpressionVariablePtr expressionVariable_y = std::make_shared<ExpressionVariable>(var_y);
+
+    Variables variables = { var_x, var_y };
+    problem->add(variables);
+
+    NonlinearObjectiveFunctionPtr objectiveFunction
+        = std::make_shared<NonlinearObjectiveFunction>(E_ObjectiveFunctionDirection::Minimize);
+
+    NonlinearExpressionPtr exprTimes
+        = std::make_shared<ExpressionProduct>(std::make_shared<ExpressionConstant>(4.0), expressionVariable_y);
+    NonlinearExpressionPtr exprMinus
+        = std::make_shared<ExpressionSum>(expressionVariable_x, std::make_shared<ExpressionNegate>(exprTimes));
+    NonlinearExpressionPtr exprPower
+        = std::make_shared<ExpressionPower>(exprMinus, std::make_shared<ExpressionConstant>(2.0));
+
+    objectiveFunction->add(exprPower);
+    problem->add(objectiveFunction);
+
+    LinearTerms linearTerms;
+    linearTerms.add(std::make_shared<LinearTerm>(1.0, var_x));
+    linearTerms.add(std::make_shared<LinearTerm>(1.0, var_y));
+    // The constructor already stores the terms, so they must not be added a second time
+    auto linearConstraint = std::make_shared<LinearConstraint>("linconstr", linearTerms, 3.0, 3.0);
+    problem->add(linearConstraint);
+
+    problem->finalize();
+
+    return (problem);
+}
+
+/* Builds
+ *
+ *     max  -(x - 4y)^2
+ *     s.t. x + y == 3
+ *          0.1 <= x <= 3, 0.1 <= y <= 10
+ *
+ * the same problem as above but maximized, so the optimum is again x = 2.4, y = 0.6 with objective value 0. An
+ * objective whose sense is dropped, or applied twice, does not land on that point.
+ *
+ * The objective is concave, so maximizing it is a convex problem. That matters because Uno solves the subproblems
+ * with whichever solver it was built with, and HiGHS rejects negative curvature outright, so a nonconvex problem
+ * would test the capabilities of the Uno build rather than this interface.
+ */
+ProblemPtr createMaximizationProblem(EnvironmentPtr env)
+{
+    ProblemPtr problem = std::make_shared<Problem>(env);
+
+    auto var_x = std::make_shared<Variable>("x", E_VariableType::Real, 0.1, 3.0);
+    ExpressionVariablePtr expressionVariable_x = std::make_shared<ExpressionVariable>(var_x);
+
+    auto var_y = std::make_shared<Variable>("y", E_VariableType::Real, 0.1, 10.0);
+    ExpressionVariablePtr expressionVariable_y = std::make_shared<ExpressionVariable>(var_y);
+
+    Variables variables = { var_x, var_y };
+    problem->add(variables);
+
+    NonlinearObjectiveFunctionPtr objectiveFunction
+        = std::make_shared<NonlinearObjectiveFunction>(E_ObjectiveFunctionDirection::Maximize);
+
+    NonlinearExpressionPtr exprTimes
+        = std::make_shared<ExpressionProduct>(std::make_shared<ExpressionConstant>(4.0), expressionVariable_y);
+    NonlinearExpressionPtr exprMinus
+        = std::make_shared<ExpressionSum>(expressionVariable_x, std::make_shared<ExpressionNegate>(exprTimes));
+    NonlinearExpressionPtr exprPower
+        = std::make_shared<ExpressionPower>(exprMinus, std::make_shared<ExpressionConstant>(2.0));
+
+    objectiveFunction->add(std::make_shared<ExpressionNegate>(exprPower));
+    problem->add(objectiveFunction);
+
+    LinearTerms linearTerms;
+    linearTerms.add(std::make_shared<LinearTerm>(1.0, var_x));
+    linearTerms.add(std::make_shared<LinearTerm>(1.0, var_y));
+    problem->add(std::make_shared<LinearConstraint>("linconstr", linearTerms, 3.0, 3.0));
+
+    problem->finalize();
+
+    return (problem);
+}
+
+bool isSolved(E_NLPSolutionStatus status)
+{
+    return (status == E_NLPSolutionStatus::Optimal || status == E_NLPSolutionStatus::Feasible);
+}
+
+} // namespace
+
+/* Solves a convex QP-like problem whose optimum is known analytically. This checks the whole chain end to end:
+   sparsity patterns, the Jacobian and Hessian value callbacks, the bounds, and reading the solution back. */
+bool UnoTest1()
+{
+    bool passed = true;
+
+    std::unique_ptr<Solver> solver = std::make_unique<Solver>();
+    auto env = solver->getEnvironment();
+
+    auto problem = createMinimizationProblem(env);
+    env->problem = problem;
+
+    auto NLPSolver = std::make_shared<NLPSolverUno>(env, problem);
+
+    std::cout << "Solver: " << NLPSolver->getSolverDescription() << '\n';
+
+    NLPSolver->setStartingPoint(std::vector<int>({ 0, 1 }), std::vector<double>({ 1.0, 1.0 }));
+
+    auto status = NLPSolver->solveProblem();
+
+    if(!isSolved(status))
+    {
+        std::cout << "FAILED: Uno did not solve the problem, status " << static_cast<int>(status) << '\n';
+        return (false);
+    }
+
+    auto solution = NLPSolver->getSolution();
+
+    std::cout << "Objective value: " << NLPSolver->getObjectiveValue() << '\n';
+    Utilities::displayVector(solution);
+
+    if(solution.size() != 2)
+    {
+        std::cout << "FAILED: expected a solution with 2 components, got " << solution.size() << '\n';
+        return (false);
+    }
+
+    if(std::abs(solution.at(0) - 2.4) > 1e-4 || std::abs(solution.at(1) - 0.6) > 1e-4)
+    {
+        std::cout << "FAILED: expected the solution (2.4, 0.6)\n";
+        passed = false;
+    }
+
+    if(std::abs(NLPSolver->getObjectiveValue()) > 1e-6)
+    {
+        std::cout << "FAILED: expected the objective value 0\n";
+        passed = false;
+    }
+
+    return (passed);
+}
+
+/* Solves a maximization problem, which is where an objective sense that is dropped or applied twice shows up, and
+   compares the result against Ipopt when it is available. The comparison is the guard against a Lagrangian Hessian
+   that is transposed or signed the wrong way: such a Hessian usually still converges, but to a different point. */
+bool UnoTest2()
+{
+    bool passed = true;
+
+    std::unique_ptr<Solver> solver = std::make_unique<Solver>();
+    auto env = solver->getEnvironment();
+
+    auto problem = createMaximizationProblem(env);
+    env->problem = problem;
+
+    auto NLPSolver = std::make_shared<NLPSolverUno>(env, problem);
+
+    NLPSolver->setStartingPoint(std::vector<int>({ 0, 1 }), std::vector<double>({ 0.5, 0.5 }));
+
+    auto status = NLPSolver->solveProblem();
+
+    if(!isSolved(status))
+    {
+        std::cout << "FAILED: Uno did not solve the maximization problem, status " << static_cast<int>(status)
+                  << '\n';
+        return (false);
+    }
+
+    auto solution = NLPSolver->getSolution();
+    double objectiveValue = NLPSolver->getObjectiveValue();
+
+    std::cout << "Uno objective value: " << objectiveValue << '\n';
+    Utilities::displayVector(solution);
+
+    /* The objective value must be the one of the point that was returned, in the sense of the model. Recomputing it
+       from the solution catches a value that was reported with the wrong sign. */
+    double recomputedObjective = problem->objectiveFunction->calculateValue(solution);
+
+    if(std::abs(objectiveValue - recomputedObjective) > 1e-6)
+    {
+        std::cout << "FAILED: the reported objective value " << objectiveValue
+                  << " does not match the objective at the returned point " << recomputedObjective << '\n';
+        passed = false;
+    }
+
+    if(std::abs(objectiveValue) > 1e-6)
+    {
+        std::cout << "FAILED: expected the objective value 0\n";
+        passed = false;
+    }
+
+    if(solution.size() != 2 || std::abs(solution.at(0) - 2.4) > 1e-4 || std::abs(solution.at(1) - 0.6) > 1e-4)
+    {
+        std::cout << "FAILED: expected the solution (2.4, 0.6)\n";
+        passed = false;
+    }
+
+#ifdef HAS_IPOPT
+    std::unique_ptr<Solver> ipoptSolverEnv = std::make_unique<Solver>();
+    auto ipoptEnv = ipoptSolverEnv->getEnvironment();
+
+    auto ipoptProblem = createMaximizationProblem(ipoptEnv);
+    ipoptEnv->problem = ipoptProblem;
+
+    auto ipoptNLPSolver = std::make_shared<NLPSolverIpoptRelaxed>(ipoptEnv, ipoptProblem);
+    ipoptNLPSolver->setStartingPoint(std::vector<int>({ 0, 1 }), std::vector<double>({ 0.5, 0.5 }));
+
+    if(isSolved(ipoptNLPSolver->solveProblem()))
+    {
+        std::cout << "Ipopt objective value: " << ipoptNLPSolver->getObjectiveValue() << '\n';
+
+        if(std::abs(objectiveValue - ipoptNLPSolver->getObjectiveValue()) > 1e-4)
+        {
+            std::cout << "FAILED: Uno and Ipopt disagree on the objective value\n";
+            passed = false;
+        }
+    }
+    else
+    {
+        std::cout << "Ipopt did not solve the problem, skipping the comparison\n";
+    }
+#endif
+
+    return (passed);
+}
+
+/* Fixing a variable collapses its bounds, which is how SHOT fixes the integers of the fixed-integer NLP, and is the
+   path through Uno's handling of variables whose bounds are equal. Unfixing has to restore the original bounds. */
+bool UnoTest3()
+{
+    bool passed = true;
+
+    std::unique_ptr<Solver> solver = std::make_unique<Solver>();
+    auto env = solver->getEnvironment();
+
+    auto problem = createMinimizationProblem(env);
+    env->problem = problem;
+
+    auto NLPSolver = std::make_shared<NLPSolverUno>(env, problem);
+
+    // With x fixed to 1, the constraint forces y = 2, so the objective is (1 - 8)^2 = 49.
+    NLPSolver->fixVariables(std::vector<int>({ 0 }), std::vector<double>({ 1.0 }));
+
+    auto status = NLPSolver->solveProblem();
+
+    if(!isSolved(status))
+    {
+        std::cout << "FAILED: Uno did not solve the problem with a fixed variable, status "
+                  << static_cast<int>(status) << '\n';
+        return (false);
+    }
+
+    auto solution = NLPSolver->getSolution();
+
+    std::cout << "Objective value with x fixed: " << NLPSolver->getObjectiveValue() << '\n';
+    Utilities::displayVector(solution);
+
+    if(std::abs(solution.at(0) - 1.0) > 1e-6)
+    {
+        std::cout << "FAILED: the fixed variable did not keep its value\n";
+        passed = false;
+    }
+
+    if(std::abs(NLPSolver->getObjectiveValue() - 49.0) > 1e-4)
+    {
+        std::cout << "FAILED: expected the objective value 49 with x fixed to 1\n";
+        passed = false;
+    }
+
+    // After unfixing, the unrestricted optimum must be found again.
+    NLPSolver->unfixVariables();
+
+    if(!isSolved(NLPSolver->solveProblem()))
+    {
+        std::cout << "FAILED: Uno did not solve the problem after unfixing\n";
+        return (false);
+    }
+
+    if(std::abs(NLPSolver->getObjectiveValue()) > 1e-6)
+    {
+        std::cout << "FAILED: expected the objective value 0 after unfixing, got "
+                  << NLPSolver->getObjectiveValue() << '\n';
+        passed = false;
+    }
+
+    return (passed);
+}
+
+int UnoTest(int argc, char* argv[])
+{
+    int defaultchoice = 1;
+    int choice = defaultchoice;
+
+    if(argc > 1)
+    {
+        if(sscanf(argv[1], "%d", &choice) != 1)
+        {
+            printf("Couldn't parse that input as a number\n");
+            return -1;
+        }
+    }
+
+    bool passed = true;
+
+    switch(choice)
+    {
+    case 1:
+        std::cout << "Starting test to solve a constrained problem using Uno:" << std::endl;
+        passed = UnoTest1();
+        std::cout << "Finished test to solve a constrained problem using Uno." << std::endl;
+        break;
+    case 2:
+        std::cout << "Starting test to solve a maximization problem using Uno:" << std::endl;
+        passed = UnoTest2();
+        std::cout << "Finished test to solve a maximization problem using Uno." << std::endl;
+        break;
+    case 3:
+        std::cout << "Starting test to solve a problem with fixed variables using Uno:" << std::endl;
+        passed = UnoTest3();
+        std::cout << "Finished test to solve a problem with fixed variables using Uno." << std::endl;
+        break;
+    default:
+        passed = false;
+        std::cout << "Test #" << choice << " does not exist!\n";
+    }
+
+    if(passed)
+        return 0;
+    else
+        return -1;
+}


### PR DESCRIPTION
This pull request adds support for the Uno NLP solver as an optional backend for the fixed-integer primal heuristic in SHOT. The integration includes build system changes, new source files, updates to documentation, and new settings for configuring Uno. The most important changes are summarized below.

**Build system and integration:**

* Added `HAS_UNO` CMake option (default OFF) and `UNO_DIR` variable to enable and locate Uno; integrated Uno detection and linking in `CMakeLists.txt`. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR69-R71) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR378-R395) [[3]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR872-R881)
* Introduced `misc/FindUno.cmake` to locate Uno's library and headers, handling both shared and static builds, and ensuring dependencies like BLAS, LAPACK, and the Fortran runtime are linked as needed.

**Source code and solver support:**

* Added `NLPSolverUno` class (`src/NLPSolver/NLPSolverUno.h`) implementing the Uno backend, with all Uno API calls encapsulated in the implementation file for maintainability.
* Extended enums and settings to support Uno as a valid NLP solver (`ES_PrimalNLPSolver::Uno`, `ES_UnoPreset`, `ES_UnoHessianModel` in `src/Enums.h`), and updated relevant code to recognize and handle Uno as a solver option (e.g., `Results.cpp`, `SHOT.cpp`, `SHOTpy.cpp`, and `Solver.cpp`). [[1]](diffhunk://#diff-6644af4fdbd850117b6bd9cb69444adca039fac1a12f69dbbef261c2dd73042dR320-R333) [[2]](diffhunk://#diff-6644af4fdbd850117b6bd9cb69444adca039fac1a12f69dbbef261c2dd73042dR404) [[3]](diffhunk://#diff-f2381a39905da22ace125fe8e75451621187a25601506a8d3b482762ab94d99dR1224-R1229) [[4]](diffhunk://#diff-5341658c1030cc3ce1fcb80ef03d60581a8cad1d5f3b204dcdf27a6a7e1d6fa9R286) [[5]](diffhunk://#diff-38049d5f08e7aaae2593577cac8d59ad042d89321a21bbe47d883395fc962f6eR1374)

**User interface and configuration:**

* Updated command-line parsing and help output to allow `--nlp=uno` as a valid option, and documented this in both the command-line usage and compilation instructions. [[1]](diffhunk://#diff-3ce963328db1b467a506597fffb984c1fcab6366500004fedbbb01e100137d6eR143-R146) [[2]](diffhunk://#diff-3ce963328db1b467a506597fffb984c1fcab6366500004fedbbb01e100137d6eR429-R433) [[3]](diffhunk://#diff-a6069968e5baece610f86c87a372824a83d63a2a759b5b2cee2bfe93a19bd17bL53-R53) [[4]](diffhunk://#diff-4a1c94f01fed5b9e5d9b916ae50640d0dfa77153dbcf691317687170d60277a1R80-R120) [[5]](diffhunk://#diff-4a1c94f01fed5b9e5d9b916ae50640d0dfa77153dbcf691317687170d60277a1R177)
* Added new settings under the `Subsolver.Uno.*` namespace for configuring Uno-specific options (algorithm preset, Hessian model, tolerances, etc.) in `Solver.cpp`.

**Documentation and developer notes:**

* Expanded documentation to cover Uno integration, build instructions, and option descriptions in `CompilationInstructions.md` and `CommandLineUsage.md`. [[1]](diffhunk://#diff-4a1c94f01fed5b9e5d9b916ae50640d0dfa77153dbcf691317687170d60277a1R80-R120) [[2]](diffhunk://#diff-4a1c94f01fed5b9e5d9b916ae50640d0dfa77153dbcf691317687170d60277a1R177) [[3]](diffhunk://#diff-a6069968e5baece610f86c87a372824a83d63a2a759b5b2cee2bfe93a19bd17bL53-R53)
* Added a developer note in `DebuggingSHOT.md` clarifying a subtlety with `createSetting` overloads for string settings.

These changes collectively enable SHOT to use Uno as an alternative NLP solver, with robust build-time detection, user-facing configuration, and comprehensive documentation.