### PR TITLE
Calculate the solution change norm and use it for dual stagnation

### DIFF
--- a/src/DualSolver.cpp
+++ b/src/DualSolver.cpp
@@ -156,6 +156,17 @@ std::pair<double, double> DualSolver::calculateHyperplaneHashes(NumericHyperplan
 
 void DualSolver::addHyperplane(HyperplanePtr hyperplane)
 {
+    // The point the hyperplane is generated in is kept, so that the distance the points move between iterations
+    // can be calculated. Only the first point of an iteration is kept, since that is the one the distance is
+    // calculated from, and keeping every point would grow with the number of hyperplanes generated.
+    if(auto numericHP = std::dynamic_pointer_cast<NumericHyperplane>(hyperplane))
+    {
+        auto currentIteration = env->results->getCurrentIteration();
+
+        if(currentIteration->hyperplanePoints.size() == 0)
+            currentIteration->hyperplanePoints.push_back(numericHP->generatedPoint);
+    }
+
     if(auto objectiveHP = std::dynamic_pointer_cast<ObjectiveHyperplane>(hyperplane))
     {
         assert((int)objectiveHP->generatedPoint.size() == env->reformulatedProblem->properties.numberOfVariables);

--- a/src/Iteration.h
+++ b/src/Iteration.h
@@ -61,6 +61,8 @@ public:
 
     bool forceObjectiveReductionCut = false;
 
+    // The point the first hyperplane of the iteration was generated in, used to calculate how far the points
+    // move between iterations
     std::vector<VectorDouble> hyperplanePoints;
 
     SolutionPoint getSolutionPointWithSmallestDeviation();

--- a/src/MIPSolver/MIPSolverCallbackBase.h
+++ b/src/MIPSolver/MIPSolverCallbackBase.h
@@ -20,6 +20,7 @@
 #include "../Tasks/TaskSelectHyperplanesECP.h"
 #include "../Tasks/TaskSelectHyperplanesExternal.h"
 #include "../Tasks/TaskUpdateInteriorPoint.h"
+#include "../Tasks/TaskCalculateSolutionChangeNorm.h"
 
 #include <memory>
 #include <optional>
@@ -50,6 +51,10 @@ protected:
     std::shared_ptr<TaskBase> taskSelectHPPts;
     std::shared_ptr<TaskSelectHyperplanesObjectiveFunction> taskSelectHPPtsByObjectiveRootsearch;
     std::shared_ptr<TaskSelectHyperplanesExternal> taskSelectExternalHPs;
+
+    // The iterations of the single-tree strategy are created in the callbacks, so the distance between the points
+    // the hyperplanes are generated in is calculated there as well
+    std::shared_ptr<TaskCalculateSolutionChangeNorm> taskCalculateSolutionChangeNorm;
 
     std::shared_ptr<TaskSelectPrimalCandidatesFromNLP> taskSelectPrimNLPOriginal;
     std::shared_ptr<TaskSelectPrimalCandidatesFromNLP> taskSelectPrimNLPReformulated;

--- a/src/MIPSolver/MIPSolverCplexSingleTree.cpp
+++ b/src/MIPSolver/MIPSolverCplexSingleTree.cpp
@@ -56,6 +56,8 @@ CplexCallback::CplexCallback(EnvironmentPtr envPtr, const IloNumVarArray& vars, 
 
     taskSelectExternalHPs = std::make_shared<TaskSelectHyperplanesExternal>(env);
 
+    taskCalculateSolutionChangeNorm = std::make_shared<TaskCalculateSolutionChangeNorm>(env);
+
     auto NLPProblemSource = static_cast<ES_PrimalNLPProblemSource>(
         env->settings->getSetting<int>("Primal.FixedInteger.SourceProblem"));
 
@@ -234,6 +236,10 @@ void CplexCallback::invoke(const IloCplex::Callback::Context& context)
                     }
 
                     taskSelectExternalHPs->run(solutionPoints);
+
+                    // The hyperplanes of the iteration have all been generated here, so the distance to the point
+                    // of the previous one can be calculated
+                    taskCalculateSolutionChangeNorm->run();
 
                     env->results->getCurrentIteration()->relaxedLazyHyperplanesAdded
                         += (env->dualSolver->hyperplaneWaitingList.size() - waitingListSize);
@@ -595,6 +601,10 @@ void CplexCallback::addLazyConstraint(
         }
 
         taskSelectExternalHPs->run(candidatePoints);
+
+        // The hyperplanes of the iteration have all been generated here, so the distance to the point
+        // of the previous one can be calculated
+        taskCalculateSolutionChangeNorm->run();
 
         // Cplex discards the candidate when it is rejected, whether or not the constraints added with it are
         // violated there. A candidate fulfilling the nonlinear constraints must therefore not be rejected unless

--- a/src/MIPSolver/MIPSolverCplexSingleTreeLegacy.cpp
+++ b/src/MIPSolver/MIPSolverCplexSingleTreeLegacy.cpp
@@ -54,6 +54,8 @@ HCallbackI::HCallbackI(EnvironmentPtr envPtr, IloEnv iloEnv, IloNumVarArray xx2)
     }
 
     taskSelectExternalHPs = std::make_shared<TaskSelectHyperplanesExternal>(env);
+
+    taskCalculateSolutionChangeNorm = std::make_shared<TaskCalculateSolutionChangeNorm>(env);
 }
 
 IloCplex::CallbackI* HCallbackI::duplicateCallback() const { return (new(getEnv()) HCallbackI(*this)); }
@@ -157,6 +159,10 @@ void HCallbackI::main() // Called at each node...
 
         taskSelectExternalHPs->run(solutionPoints);
 
+        // The hyperplanes of the iteration have all been generated here, so the distance to the point
+        // of the previous one can be calculated
+        taskCalculateSolutionChangeNorm->run();
+
         env->results->getCurrentIteration()->relaxedLazyHyperplanesAdded
             += (env->dualSolver->hyperplaneWaitingList.size() - waitingListSize);
     }
@@ -242,6 +248,8 @@ CtCallbackI::CtCallbackI(EnvironmentPtr envPtr, IloEnv iloEnv, IloNumVarArray xx
     }
 
     taskSelectExternalHPs = std::make_shared<TaskSelectHyperplanesExternal>(env);
+
+    taskCalculateSolutionChangeNorm = std::make_shared<TaskCalculateSolutionChangeNorm>(env);
 
     auto NLPProblemSource = static_cast<ES_PrimalNLPProblemSource>(
         env->settings->getSetting<int>("Primal.FixedInteger.SourceProblem"));
@@ -509,6 +517,10 @@ void CtCallbackI::main()
     }
 
     taskSelectExternalHPs->run(candidatePoints);
+
+    // The hyperplanes of the iteration have all been generated here, so the distance to the point
+    // of the previous one can be calculated
+    taskCalculateSolutionChangeNorm->run();
 
     for(auto& hp : env->dualSolver->hyperplaneWaitingList)
     {

--- a/src/MIPSolver/MIPSolverGurobiSingleTree.cpp
+++ b/src/MIPSolver/MIPSolverGurobiSingleTree.cpp
@@ -352,6 +352,10 @@ void GurobiCallbackSingleTree::callback()
 
                 taskSelectExternalHPs->run(solutionPoints);
 
+                // The hyperplanes of the iteration have all been generated here, so the distance to the point
+                // of the previous one can be calculated
+                taskCalculateSolutionChangeNorm->run();
+
                 env->results->getCurrentIteration()->relaxedLazyHyperplanesAdded
                     += (env->dualSolver->hyperplaneWaitingList.size() - waitingListSize);
             }
@@ -605,6 +609,8 @@ GurobiCallbackSingleTree::GurobiCallbackSingleTree(GRBVar* xvars, EnvironmentPtr
 
     taskSelectExternalHPs = std::make_shared<TaskSelectHyperplanesExternal>(env);
 
+    taskCalculateSolutionChangeNorm = std::make_shared<TaskCalculateSolutionChangeNorm>(env);
+
     auto NLPProblemSource = static_cast<ES_PrimalNLPProblemSource>(
         env->settings->getSetting<int>("Primal.FixedInteger.SourceProblem"));
 
@@ -713,6 +719,10 @@ void GurobiCallbackSingleTree::addLazyConstraint(std::vector<SolutionPoint> cand
         }
 
         taskSelectExternalHPs->run(candidatePoints);
+
+        // The hyperplanes of the iteration have all been generated here, so the distance to the point
+        // of the previous one can be calculated
+        taskCalculateSolutionChangeNorm->run();
 
         for(auto& hp : env->dualSolver->hyperplaneWaitingList)
         {

--- a/src/MIPSolver/RelaxationStrategyStandard.cpp
+++ b/src/MIPSolver/RelaxationStrategyStandard.cpp
@@ -77,6 +77,10 @@ void RelaxationStrategyStandard::executeStrategy()
     {
         this->setInactive();
     }
+    else if(isSolutionChangeStagnant())
+    {
+        this->setInactive();
+    }
     else
     {
         this->setActive();
@@ -140,6 +144,27 @@ bool RelaxationStrategyStandard::isTimeLimitReached()
 }
 
 bool RelaxationStrategyStandard::isLPStepFinished() { return (LPFinished); }
+
+bool RelaxationStrategyStandard::isSolutionChangeStagnant()
+{
+    double tolerance = env->settings->getSetting<double>("Dual.Relaxation.SolutionChangeTolerance");
+
+    if(tolerance <= 0.0)
+        return (false);
+
+    if(env->results->getNumberOfIterations() < 2)
+        return (false);
+
+    // The hyperplanes of the relaxed problems are generated in points on the boundary of the nonlinear feasible
+    // set, so when those points stop moving the linearization is no longer improving and there is nothing more to
+    // gain from continuing with relaxed problems
+    auto prevIter = env->results->getPreviousIteration();
+
+    if(prevIter->boundaryDistance == SHOT_DBL_MAX)
+        return (false);
+
+    return (prevIter->boundaryDistance < tolerance);
+}
 
 bool RelaxationStrategyStandard::isObjectiveStagnant()
 {

--- a/src/MIPSolver/RelaxationStrategyStandard.h
+++ b/src/MIPSolver/RelaxationStrategyStandard.h
@@ -33,6 +33,7 @@ private:
     bool isIterationLimitReached();
     bool isTimeLimitReached();
     bool isLPStepFinished();
+    bool isSolutionChangeStagnant();
     bool isObjectiveStagnant();
 
     bool LPFinished;

--- a/src/SolutionStrategy/SolutionStrategyMultiTree.cpp
+++ b/src/SolutionStrategy/SolutionStrategyMultiTree.cpp
@@ -52,6 +52,7 @@
 #include "../Tasks/TaskSelectHyperplanesObjectiveFunction.h"
 #include "../Tasks/TaskSelectHyperplanesExternal.h"
 #include "../Tasks/TaskAddHyperplanes.h"
+#include "../Tasks/TaskCalculateSolutionChangeNorm.h"
 
 #include "../Tasks/TaskAddIntegerCuts.h"
 
@@ -324,6 +325,14 @@ SolutionStrategyMultiTree::SolutionStrategyMultiTree(EnvironmentPtr envPtr)
     env->tasks->addTask(tSelectExternalHPs, "SelectExternalHPs");
 
     env->tasks->addTask(tAddHPs, "AddHPs");
+
+    // The distance between the points the hyperplanes are generated in is calculated once they have been
+    // generated, and is used by the relaxation strategy in the next iteration
+    if(env->reformulatedProblem->properties.numberOfNonlinearConstraints > 0)
+    {
+        auto tCalculateSolutionChangeNorm = std::make_shared<TaskCalculateSolutionChangeNorm>(env);
+        env->tasks->addTask(tCalculateSolutionChangeNorm, "CalculateSolutionChangeNorm");
+    }
 
     if(env->settings->getSetting<bool>("Dual.HyperplaneCuts.UseIntegerCuts"))
     {

--- a/src/SolutionStrategy/SolutionStrategyNLP.cpp
+++ b/src/SolutionStrategy/SolutionStrategyNLP.cpp
@@ -49,6 +49,7 @@
 #include "../Tasks/TaskSelectHyperplanesObjectiveFunction.h"
 #include "../Tasks/TaskSelectHyperplanesExternal.h"
 #include "../Tasks/TaskAddHyperplanes.h"
+#include "../Tasks/TaskCalculateSolutionChangeNorm.h"
 
 #include "../Tasks/TaskAddIntegerCuts.h"
 
@@ -238,6 +239,14 @@ SolutionStrategyNLP::SolutionStrategyNLP(EnvironmentPtr envPtr)
     env->tasks->addTask(tSelectExternalHPs, "SelectExternalHPs");
 
     env->tasks->addTask(tAddHPs, "AddHPs");
+
+    // The distance between the points the hyperplanes are generated in is calculated once they have been
+    // generated
+    if(env->reformulatedProblem->properties.numberOfNonlinearConstraints > 0)
+    {
+        auto tCalculateSolutionChangeNorm = std::make_shared<TaskCalculateSolutionChangeNorm>(env);
+        env->tasks->addTask(tCalculateSolutionChangeNorm, "CalculateSolutionChangeNorm");
+    }
 
     env->tasks->addTask(tUpdateExternalDualBound, "UpdateExternalDualBound");
 

--- a/src/SolutionStrategy/SolutionStrategySingleTree.cpp
+++ b/src/SolutionStrategy/SolutionStrategySingleTree.cpp
@@ -52,6 +52,7 @@
 #include "../Tasks/TaskSelectHyperplanesObjectiveFunction.h"
 #include "../Tasks/TaskSelectHyperplanesExternal.h"
 #include "../Tasks/TaskAddHyperplanes.h"
+#include "../Tasks/TaskCalculateSolutionChangeNorm.h"
 
 #include "../Tasks/TaskAddIntegerCuts.h"
 
@@ -297,6 +298,14 @@ SolutionStrategySingleTree::SolutionStrategySingleTree(EnvironmentPtr envPtr)
     env->tasks->addTask(tSelectExternalHPs, "SelectExternalHPs");
 
     env->tasks->addTask(tAddHPs, "AddHPs");
+
+    // The distance between the points the hyperplanes are generated in is calculated once they have been
+    // generated
+    if(env->reformulatedProblem->properties.numberOfNonlinearConstraints > 0)
+    {
+        auto tCalculateSolutionChangeNorm = std::make_shared<TaskCalculateSolutionChangeNorm>(env);
+        env->tasks->addTask(tCalculateSolutionChangeNorm, "CalculateSolutionChangeNorm");
+    }
 
     if(env->settings->getSetting<bool>("Dual.HyperplaneCuts.UseIntegerCuts"))
     {

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -1031,6 +1031,11 @@ void Solver::initializeSettings()
     env->settings->createSetting(
         "Dual.Relaxation.TerminationTolerance", 0.5, "Time limit (s) when solving LP problems initially");
 
+    env->settings->createSetting("Dual.Relaxation.SolutionChangeTolerance", 0.0,
+        "End the initial LP phase when the hyperplanes are generated in points this close to each other: 0: "
+        "Disable",
+        0.0, SHOT_DBL_MAX);
+
     env->settings->createSetting(
         "Dual.Relaxation.TimeLimit", 30.0, "Time limit (s) when solving LP problems initially", 0, SHOT_DBL_MAX);
 

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -1779,6 +1779,15 @@ void Solver::initializeSettings()
     env->settings->createSetting("Termination.DualStagnation.IterationLimit", 1000,
         "Max number of iterations without significant dual objective value improvement", 0, SHOT_INT_MAX);
 
+    env->settings->createSetting("Termination.DualStagnation.SolutionChangeIterationLimit", 10,
+        "Number of iterations in a row the hyperplane points may stay within the tolerance before termination", 1,
+        SHOT_INT_MAX);
+
+    env->settings->createSetting("Termination.DualStagnation.SolutionChangeTolerance", 0.0,
+        "Max distance between the points the hyperplanes are generated in for the dual problem to have stagnated: "
+        "0: Disable",
+        0.0, SHOT_DBL_MAX);
+
     env->settings->createSetting("Termination.PrimalStagnation.IterationLimit", 50,
         "Max number of iterations without significant primal objective value improvement", 0, SHOT_INT_MAX);
 

--- a/src/Tasks/TaskCalculateSolutionChangeNorm.cpp
+++ b/src/Tasks/TaskCalculateSolutionChangeNorm.cpp
@@ -11,9 +11,13 @@
 #include "TaskCalculateSolutionChangeNorm.h"
 
 #include "../Iteration.h"
+#include "../Output.h"
 #include "../Results.h"
 #include "../Settings.h"
 #include "../TaskHandler.h"
+#include "../Utilities.h"
+
+#include <cmath>
 
 namespace SHOT
 {
@@ -29,44 +33,36 @@ void TaskCalculateSolutionChangeNorm::run()
     currIter->boundaryDistance = SHOT_DBL_MAX;
 
     if(env->results->getNumberOfIterations() < 3)
-    {
         return;
-    }
 
-    if(env->results->getCurrentIteration()->hyperplanePoints.size() == 0
-        || env->results->getCurrentIteration()->isMIP())
-    {
+    if(currIter->hyperplanePoints.size() == 0)
         return;
-    }
 
-    auto currIterSol = env->results->getCurrentIteration()->hyperplanePoints.at(0);
+    auto currIterSol = currIter->hyperplanePoints.at(0);
 
+    // The distance is calculated to the last iteration that also generated a hyperplane, whether the dual
+    // problem was a relaxation there or not
     for(int i = env->results->getNumberOfIterations() - 2; i >= 1; i--)
     {
-        if(env->results->getNumberOfIterations() > 0 && !env->results->iterations.at(i)->isMIP())
-        {
-            auto prevIterSol = env->results->iterations.at(i)->hyperplanePoints.at(0);
+        auto previousIteration = env->results->iterations.at(i);
 
-            double distance = 0;
+        if(previousIteration->hyperplanePoints.size() == 0)
+            continue;
 
-            for(size_t j = 0; j < currIterSol.size(); j++)
-            {
-                distance = distance + (currIterSol.at(j) - prevIterSol.at(j)) * (currIterSol.at(j) - prevIterSol.at(j));
-            }
+        auto prevIterSol = previousIteration->hyperplanePoints.at(0);
 
-            distance = sqrt(distance + 0.001);
+        if(prevIterSol.size() != currIterSol.size())
+            continue;
 
-            if(std::isnan(distance)) // Checks for INF, do not remove!
-            {
-                currIter->boundaryDistance = SHOT_DBL_MAX;
-            }
-            else
-            {
-                currIter->boundaryDistance = distance;
-            }
+        double distance = Utilities::L2Norm(currIterSol, prevIterSol);
 
-            return;
-        }
+        // Checks for INF, do not remove!
+        currIter->boundaryDistance = std::isnan(distance) ? SHOT_DBL_MAX : distance;
+
+        env->output->outputDebug(fmt::format("        The hyperplane generation point moved {} from iteration {}.",
+            currIter->boundaryDistance, previousIteration->iterationNumber));
+
+        return;
     }
 }
 

--- a/src/Tasks/TaskCheckDualStagnation.cpp
+++ b/src/Tasks/TaskCheckDualStagnation.cpp
@@ -38,6 +38,31 @@ void TaskCheckDualStagnation::run()
         return;
     }
 
+    // The hyperplanes are generated in points on the boundary of the nonlinear feasible set, and when those
+    // points stop moving the linearization no longer changes, however many cuts are still being added. The dual
+    // bound can keep creeping in that state without the dual problem getting anywhere.
+    if(double solutionChangeTolerance
+        = env->settings->getSetting<double>("Termination.DualStagnation.SolutionChangeTolerance");
+        solutionChangeTolerance > 0.0 && currIter->boundaryDistance != SHOT_DBL_MAX)
+    {
+        if(currIter->boundaryDistance < solutionChangeTolerance)
+            numberOfIterationsWithStagnantSolution++;
+        else
+            numberOfIterationsWithStagnantSolution = 0;
+
+        // The limit is separate from the one for the dual bound, since the two criteria are unrelated and lowering
+        // one should not make the other terminate earlier
+        if(numberOfIterationsWithStagnantSolution
+            >= env->settings->getSetting<int>("Termination.DualStagnation.SolutionChangeIterationLimit"))
+        {
+            env->results->terminationReason = E_TerminationReason::ObjectiveStagnation;
+            env->tasks->setNextTask(taskIDIfTrue);
+            env->results->terminationReasonDescription
+                = "Terminated since the points the hyperplanes are generated in have stopped moving.";
+            return;
+        }
+    }
+
     // To avoid unnecessary termination when there are many subsequent dual problems with the same objective value
     // but different nonlinear constraint errors
     if(env->results->getNumberOfIterations() > 1

--- a/src/Tasks/TaskCheckDualStagnation.h
+++ b/src/Tasks/TaskCheckDualStagnation.h
@@ -24,5 +24,8 @@ public:
 
 private:
     std::string taskIDIfTrue;
+
+    // Counts the iterations in a row where the hyperplanes have been generated in practically the same point
+    int numberOfIterationsWithStagnantSolution = 0;
 };
 } // namespace SHOT

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -105,7 +105,8 @@ set(Solver_parts
     14
     15
     16
-    17)
+    17
+    18)
 set(cpptests ${cpptests} Solver)
 
 if(HAS_IPOPT)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -104,7 +104,8 @@ set(Solver_parts
     13
     14
     15
-    16)
+    16
+    17)
 set(cpptests ${cpptests} Solver)
 
 if(HAS_IPOPT)

--- a/test/SolverTest.cpp
+++ b/test/SolverTest.cpp
@@ -34,6 +34,7 @@
 
 #include "../src/Tasks/TaskReformulateProblem.h"
 #include "../src/Tasks/TaskCalculateSolutionChangeNorm.h"
+#include "../src/Tasks/TaskCheckDualStagnation.h"
 #include "../src/Iteration.h"
 
 using namespace SHOT;
@@ -1508,6 +1509,84 @@ bool TestSolutionChangeNorm()
     return passed;
 }
 
+bool TestDualStagnationOnSolutionChange()
+{
+    bool passed = true;
+
+    auto solver = std::make_unique<Solver>();
+    solver->updateSetting("Output.Console.LogLevel", static_cast<int>(E_LogLevel::Off));
+    solver->updateSetting("Termination.DualStagnation.SolutionChangeTolerance", 1e-3);
+    solver->updateSetting("Termination.DualStagnation.SolutionChangeIterationLimit", 3);
+
+    if(!solver->setProblem("data/tls2.osil"))
+    {
+        std::cout << "  FAILED: could not read the problem.\n";
+        return false;
+    }
+
+    auto env = solver->getEnvironment();
+
+    // The task jumps to another task when it terminates, so one has to exist under that name
+    env->tasks->addTask(std::make_shared<TaskCalculateSolutionChangeNorm>(env), "Dummy");
+    auto task = std::make_unique<TaskCheckDualStagnation>(env, "Dummy");
+
+    auto runIterationWithDistance = [&](double distance) {
+        env->results->createIteration();
+        auto iteration = env->results->getCurrentIteration();
+        iteration->isDualProblemDiscrete = true;
+        iteration->boundaryDistance = distance;
+
+        // Keeps the criterion for cuts that cannot be added from terminating first
+        env->solutionStatistics.iterationLastDualCutAdded = iteration->iterationNumber;
+
+        task->run();
+    };
+
+    // Points that keep moving are not a stagnation, however many iterations there are
+    for(int i = 0; i < 5; i++)
+        runIterationWithDistance(1.0);
+
+    if(env->results->terminationReason != E_TerminationReason::None)
+    {
+        std::cout << "  FAILED: terminated although the hyperplane points kept moving.\n";
+        passed = false;
+    }
+
+    // Two iterations where they hardly move is still below the limit of three
+    runIterationWithDistance(1e-9);
+    runIterationWithDistance(1e-9);
+
+    if(env->results->terminationReason != E_TerminationReason::None)
+    {
+        std::cout << "  FAILED: terminated before the iteration limit was reached.\n";
+        passed = false;
+    }
+
+    // A point that moves again starts the count over
+    runIterationWithDistance(1.0);
+    runIterationWithDistance(1e-9);
+    runIterationWithDistance(1e-9);
+
+    if(env->results->terminationReason != E_TerminationReason::None)
+    {
+        std::cout << "  FAILED: a point that moved did not start the count over.\n";
+        passed = false;
+    }
+
+    runIterationWithDistance(1e-9);
+
+    if(env->results->terminationReason != E_TerminationReason::ObjectiveStagnation)
+    {
+        std::cout << "  FAILED: did not terminate although the hyperplane points stopped moving.\n";
+        passed = false;
+    }
+
+    if(passed)
+        std::cout << "  The dual problem is stagnant once the hyperplane points stop moving.\n";
+
+    return passed;
+}
+
 int SolverTest(int argc, char* argv[])
 {
     int defaultchoice = 1;
@@ -1613,6 +1692,11 @@ int SolverTest(int argc, char* argv[])
         std::cout << "Starting test for the norm of the change between hyperplane points" << std::endl;
         passed = TestSolutionChangeNorm();
         std::cout << "Finished test for the norm of the change between hyperplane points." << std::endl;
+        break;
+    case 18:
+        std::cout << "Starting test for dual stagnation when the hyperplane points stop moving" << std::endl;
+        passed = TestDualStagnationOnSolutionChange();
+        std::cout << "Finished test for dual stagnation when the hyperplane points stop moving." << std::endl;
         break;
     default:
         passed = false;

--- a/test/SolverTest.cpp
+++ b/test/SolverTest.cpp
@@ -33,6 +33,8 @@
 #include "../src/RootsearchMethod/RootsearchMethodBoost.h"
 
 #include "../src/Tasks/TaskReformulateProblem.h"
+#include "../src/Tasks/TaskCalculateSolutionChangeNorm.h"
+#include "../src/Iteration.h"
 
 using namespace SHOT;
 
@@ -1422,6 +1424,90 @@ bool TestConstraintClassesForFixedVariables(const std::string& problemFile)
     return passed;
 }
 
+bool TestSolutionChangeNorm()
+{
+    bool passed = true;
+
+    auto solver = std::make_unique<Solver>();
+    solver->updateSetting("Output.Console.LogLevel", static_cast<int>(E_LogLevel::Off));
+
+    if(!solver->setProblem("data/tls2.osil"))
+    {
+        std::cout << "  FAILED: could not read the problem.\n";
+        return false;
+    }
+
+    auto env = solver->getEnvironment();
+    auto task = std::make_unique<TaskCalculateSolutionChangeNorm>(env);
+
+    // Three iterations where the dual problem is a relaxation, with the hyperplanes of the last two generated
+    // three units apart
+    VectorDouble firstPoint(env->reformulatedProblem->properties.numberOfVariables, 0.0);
+    VectorDouble secondPoint = firstPoint;
+    VectorDouble thirdPoint = firstPoint;
+    secondPoint.at(0) = 1.0;
+    thirdPoint.at(0) = 4.0;
+
+    for(auto& point : { firstPoint, secondPoint, thirdPoint })
+    {
+        env->results->createIteration();
+        auto iteration = env->results->getCurrentIteration();
+        iteration->isDualProblemDiscrete = false;
+        iteration->hyperplanePoints.push_back(point);
+    }
+
+    task->run();
+
+    double distance = env->results->getCurrentIteration()->boundaryDistance;
+
+    if(std::abs(distance - 3.0) > 1e-9)
+    {
+        std::cout << "  FAILED: the distance between the last two hyperplane points is " << distance
+                  << " instead of 3.\n";
+        passed = false;
+    }
+
+    // An iteration without hyperplanes is skipped, so the distance is taken to the last one that has any
+    env->results->createIteration();
+    auto emptyIteration = env->results->getCurrentIteration();
+    emptyIteration->isDualProblemDiscrete = false;
+
+    env->results->createIteration();
+    auto lastIteration = env->results->getCurrentIteration();
+    lastIteration->isDualProblemDiscrete = false;
+    VectorDouble lastPoint = firstPoint;
+    lastPoint.at(0) = 6.0;
+    lastIteration->hyperplanePoints.push_back(lastPoint);
+
+    task->run();
+
+    if(std::abs(lastIteration->boundaryDistance - 2.0) > 1e-9)
+    {
+        std::cout << "  FAILED: the iteration without hyperplanes was not skipped, the distance is "
+                  << lastIteration->boundaryDistance << " instead of 2.\n";
+        passed = false;
+    }
+
+    // Without any hyperplanes of its own an iteration has no distance
+    env->results->createIteration();
+    auto iterationWithoutPoints = env->results->getCurrentIteration();
+    iterationWithoutPoints->isDualProblemDiscrete = false;
+
+    task->run();
+
+    if(iterationWithoutPoints->boundaryDistance != SHOT_DBL_MAX)
+    {
+        std::cout << "  FAILED: an iteration without hyperplanes was given the distance "
+                  << iterationWithoutPoints->boundaryDistance << ".\n";
+        passed = false;
+    }
+
+    if(passed)
+        std::cout << "  The distance is calculated between the points the hyperplanes were generated in.\n";
+
+    return passed;
+}
+
 int SolverTest(int argc, char* argv[])
 {
     int defaultchoice = 1;
@@ -1522,6 +1608,11 @@ int SolverTest(int argc, char* argv[])
         std::cout << "Starting test for constraint classes with fixed variables (osil format)" << std::endl;
         passed = TestConstraintClassesForFixedVariables("data/fixedvars.osil");
         std::cout << "Finished test for constraint classes with fixed variables (osil format)." << std::endl;
+        break;
+    case 17:
+        std::cout << "Starting test for the norm of the change between hyperplane points" << std::endl;
+        passed = TestSolutionChangeNorm();
+        std::cout << "Finished test for the norm of the change between hyperplane points." << std::endl;
         break;
     default:
         passed = false;


### PR DESCRIPTION
Work in progress, parked to be continued later. Based on `fixinstances`, so only these two commits are shown here.

## What this does

**Brings `TaskCalculateSolutionChangeNorm` back to life.** It was not part of any solution strategy, the points it reads (`Iteration::hyperplanePoints`) were never recorded, and the distance it writes was last read by `RelaxationStrategyAdaptive`, which has since been removed.

- The point the first hyperplane of each iteration is generated in is recorded in `DualSolver::addHyperplane`. Only the first is kept, since that is the one the distance uses and keeping all of them grows with the number of hyperplanes.
- The norm is calculated in every iteration in the multi-tree, single-tree and NLP strategies, including the iterations created in the single-tree callbacks (CPLEX, legacy CPLEX and Gurobi). The MIQCQP strategy generates no hyperplanes, so it is not included.
- The distance no longer has `0.001` added under the square root, which put a floor of about 0.03 under it, and iterations without hyperplanes are skipped instead of indexed.

**Uses the norm in two places, both disabled by default:**

- `Dual.Relaxation.SolutionChangeTolerance` — the relaxation strategy ends the initial LP phase when the points stop moving.
- `Termination.DualStagnation.SolutionChangeTolerance` together with `Termination.DualStagnation.SolutionChangeIterationLimit` (default 10) — the dual stagnation check terminates when the points stay within the tolerance for that many iterations in a row. The limit is separate from `Termination.DualStagnation.IterationLimit`, since sharing it made the existing dual-bound criterion fire first whenever it was lowered.

Tests: `Solver_17` (the norm) and `Solver_18` (the stagnation criterion).

## Evidence so far

With both criteria disabled, the full benchmark set solves identically to the base: 60/60 in every configuration and the same iteration counts, so calculating the norm in every iteration costs nothing measurable.

For the stagnation criterion, all 78 test instances were run in both multi-tree and single-tree, counting runs of consecutive MIP iterations where the point moved less than a tolerance:

| tolerance | instances with a run of 5 or more |
|---|---|
| 1e-6 | none |
| 1e-4 | `ex1252` only, a run of 31, which runs to the time limit |

Enabling the criterion at 1e-4 on `ex1252` ends the solve after 4.3 s instead of the 30 s time limit, with the same bounds `[0, 134264]` in both strategies.

Healthy solves do produce runs of zero distances in the initial LP phase (11 in a row on `flay03m`), but the stagnation check already skips non-MIP iterations for discrete problems, so those runs are never counted there.

## Open questions before enabling anything by default

- **The tolerance is absolute, so it depends on the scaling of the problem.** A distance of 1e-4 is negligible for variables in the thousands but large for variables near 1e-3. A relative comparison, e.g. against `tol * max(1, norm of the point)`, would remove that before choosing a default.
- **The evidence is one instance.** It shows the criterion can help and does not hurt the test set, not that it is safe in general.
- **The first hyperplane point is a weak representative of an iteration.** The distances often alternate between a few recurring values, and consecutive iterations can generate their first cut in the same point while other cuts still move. A summary over all the points of an iteration may give a cleaner signal.
- **In single-tree the check sees only the latest iteration.** The stagnation task runs once per pass of the strategy loop, while the callbacks create several iterations in between, so the in-a-row count skips the intermediate ones there.
- **Whether the relaxation-strategy criterion is worth enabling** has not been measured at all.
